### PR TITLE
fix: lora.json in site-packages, feat: python 3.11 support, refactor: code cleanup + mypy compliance

### DIFF
--- a/hordelib/benchmark.py
+++ b/hordelib/benchmark.py
@@ -26,7 +26,7 @@ def download_image(url):
         raise Exception(f"Failed to download image. Status code: {response.status_code}")
 
 
-timings = {}
+timings: dict = {}
 
 
 def delta(desc):
@@ -105,9 +105,15 @@ def main():
 
     try:
         gpu = GPUInfo().get_info()
-        gpu_name = gpu["product"]
-        gpu_vram = gpu["vram_total"]
-        gpu_vram_mb = GPUInfo().get_total_vram_mb()
+        if gpu is None:
+            gpu = "unknown"
+            gpu_name = ""
+            gpu_vram = ""
+            gpu_vram_mb = 0
+        else:
+            gpu_name = gpu["product"]
+            gpu_vram = gpu["vram_total"]
+            gpu_vram_mb = GPUInfo().get_total_vram_mb()
     except Exception:
         gpu = "unknown"
         gpu_name = ""
@@ -134,7 +140,7 @@ def main():
 
     generate = HordeLib()
     delta("model-manager-load")
-    SharedModelManager.load_model_managers(compvis=True, controlnet=not disable_controlnet)
+    SharedModelManager.loadModelManagers(compvis=True, controlnet=not disable_controlnet)
     delta("model-manager-load")
     SharedModelManager.manager.load("stable_diffusion")
 
@@ -182,8 +188,8 @@ def main():
         if last > 30:
             break
         max_iterations = attempt
-    its = round(attempt / last, 1)
-    its_raw = round(attempt / (last - inference_overhead), 1)
+    its = round(attempt / last, 1)  # type: ignore # FIXME???
+    its_raw = round(attempt / (last - inference_overhead), 1)  # type: ignore # FIXME???
 
     logger.warning("Benchmarking model load/unload")
     delta("stable-diffusion-model-load-x3")
@@ -231,8 +237,8 @@ def main():
     print(f"{its:>{9}} basic inference (empirical)")
     print(f"{its_raw:>{9}} basic inference (theoretical)")
     if not disable_controlnet:
-        print(f"{cnet_its:>{9}} controlnet inference (empirical)")
-        print(f"{cnet_raw_its:>{9}} controlnet inference (theoretical)")
+        print(f"{cnet_its:>{9}} controlnet inference (empirical)")  # type: ignore # FIXME???
+        print(f"{cnet_raw_its:>{9}} controlnet inference (theoretical)")  # type: ignore # FIXME???
     print()
     print(f"{model_load:>{9}}s model load speed")
     print()

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -63,14 +63,14 @@ from hordelib.config_path import get_hordelib_path
 
 _comfy_nodes: types.ModuleType
 _comfy_PromptExecutor: types.ModuleType
-_comfy_validate_prompt: types.ModuleType
+_comfy_validate_prompt: types.FunctionType
 _comfy_folder_paths: types.ModuleType
-__comfy_load_checkpoint_guess_config: types.FunctionType
-__comfy_load_controlnet: types.FunctionType
+_comfy_load_checkpoint_guess_config: types.FunctionType
+_comfy_load_controlnet: types.FunctionType
 _comfy_model_manager: types.ModuleType | None = None
-__comfy_get_torch_device: types.FunctionType
-__comfy_get_free_memory: types.FunctionType
-__comfy_load_torch_file: types.FunctionType
+_comfy_get_torch_device: types.FunctionType
+_comfy_get_free_memory: types.FunctionType
+_comfy_load_torch_file: types.FunctionType
 _comfy_model_loading: types.ModuleType
 _canny: types.ModuleType
 _hed: types.ModuleType
@@ -85,8 +85,8 @@ _uniformer: types.ModuleType
 # isort: off
 def do_comfy_import():
     global _comfy_nodes, _comfy_PromptExecutor, _comfy_validate_prompt, _comfy_folder_paths
-    global __comfy_load_checkpoint_guess_config, __comfy_load_controlnet, _comfy_model_manager
-    global __comfy_get_torch_device, __comfy_get_free_memory, __comfy_load_torch_file, _comfy_model_loading
+    global _comfy_load_checkpoint_guess_config, _comfy_load_controlnet, _comfy_model_manager
+    global _comfy_get_torch_device, _comfy_get_free_memory, _comfy_load_torch_file, _comfy_model_loading
     global _canny, _hed, _leres, _midas, _mlsd, _openpose, _pidinet, _uniformer
 
     # Note these imports are intentionally somewhat obfuscated as a reminder to other modules
@@ -94,25 +94,25 @@ def do_comfy_import():
     # comfy should be abstracted through functions in this module.
 
     from execution import nodes as _comfy_nodes  # type: ignore
-    from execution import PromptExecutor as _comfy_PromptExecutor
-    from execution import validate_prompt as _comfy_validate_prompt
+    from execution import PromptExecutor as _comfy_PromptExecutor  # type: ignore
+    from execution import validate_prompt as _comfy_validate_prompt  # type: ignore
     from folder_paths import folder_names_and_paths as _comfy_folder_paths  # type: ignore
-    from comfy.sd import load_checkpoint_guess_config as __comfy_load_checkpoint_guess_config  # type: ignore
-    from comfy.sd import load_controlnet as __comfy_load_controlnet
+    from comfy.sd import load_checkpoint_guess_config as _comfy_load_checkpoint_guess_config  # type: ignore
+    from comfy.sd import load_controlnet as _comfy_load_controlnet  # type: ignore
     from comfy.model_management import model_manager as _comfy_model_manager  # type: ignore
-    from comfy.model_management import get_torch_device as __comfy_get_torch_device
-    from comfy.model_management import get_free_memory as __comfy_get_free_memory
-    from comfy.utils import load_torch_file as __comfy_load_torch_file  # type: ignore
+    from comfy.model_management import get_torch_device as _comfy_get_torch_device  # type: ignore
+    from comfy.model_management import get_free_memory as _comfy_get_free_memory  # type: ignore
+    from comfy.utils import load_torch_file as _comfy_load_torch_file  # type: ignore
     from comfy_extras.chainner_models import model_loading as _comfy_model_loading  # type: ignore
     from hordelib.nodes.comfy_controlnet_preprocessors import (
-        canny as _canny,
-        hed as _hed,
-        leres as _leres,
-        midas as _midas,
-        mlsd as _mlsd,
-        openpose as _openpose,
-        pidinet as _pidinet,
-        uniformer as _uniformer,
+        canny as _canny,  # type: ignore
+        hed as _hed,  # type: ignore
+        leres as _leres,  # type: ignore
+        midas as _midas,  # type: ignore
+        mlsd as _mlsd,  # type: ignore
+        openpose as _openpose,  # type: ignore
+        pidinet as _pidinet,  # type: ignore
+        uniformer as _uniformer,  # type: ignore
     )
 
 
@@ -123,11 +123,11 @@ __model_load_mutex = threading.Lock()
 
 
 def cleanup():
-    locked = _comfy_model_manager.sampler_mutex.acquire(timeout=0)
+    locked = _comfy_model_manager.sampler_mutex.acquire(timeout=0)  # type: ignore
     if locked:
         # Do we have any models waiting to be released?
         if not __models_to_release:
-            _comfy_model_manager.sampler_mutex.release()
+            _comfy_model_manager.sampler_mutex.release()  # type: ignore
             return
 
         # Can we release any of them?
@@ -153,7 +153,7 @@ def cleanup():
             gc.collect()
             logger.debug(f"Removal of model {model_name} completed")
 
-        _comfy_model_manager.sampler_mutex.release()
+        _comfy_model_manager.sampler_mutex.release()  # type: ignore
 
 
 def remove_model_from_memory(model_name, model_data):
@@ -165,19 +165,19 @@ def remove_model_from_memory(model_name, model_data):
 
 
 def get_models_on_gpu():
-    return _comfy_model_manager.get_models_on_gpu()
+    return _comfy_model_manager.get_models_on_gpu()  # type: ignore
 
 
 def get_torch_device():
-    return __comfy_get_torch_device()
+    return _comfy_get_torch_device()
 
 
 def get_torch_free_vram_mb():
-    return round(__comfy_get_free_memory() / (1024 * 1024))
+    return round(_comfy_get_free_memory() / (1024 * 1024))
 
 
 def unload_model_from_gpu(model):
-    _comfy_model_manager.unload_model(model)
+    _comfy_model_manager.unload_model(model)  # type: ignore
     garbage_collect()
 
 
@@ -192,19 +192,19 @@ def garbage_collect():
 
 def load_model_to_gpu(model):
     # Don't bother if there isn't any space
-    if not _comfy_model_manager.have_free_vram():
+    if not _comfy_model_manager.have_free_vram():  # type: ignore
         return
     # Load the model to the GPU. This would normally be done just before
     # the model is used for sampling, the caller must want more free ram.
-    return _comfy_model_manager.load_model_gpu(model)
+    return _comfy_model_manager.load_model_gpu(model)  # type: ignore
 
 
 def is_model_in_use(model):
-    return _comfy_model_manager.is_model_in_use(model)
+    return _comfy_model_manager.is_model_in_use(model)  # type: ignore
 
 
 def load_torch_file(filename):
-    result = __comfy_load_torch_file(filename)
+    result = _comfy_load_torch_file(filename)
     return result
 
 
@@ -217,7 +217,7 @@ def horde_load_checkpoint(
     ckpt_path: str,
     output_vae: bool = True,
     output_clip: bool = True,
-    embeddings_path: str = None,
+    embeddings_path: str | None = None,
 ) -> dict[str, typing.Any]:  # XXX # FIXME 'any'
     # XXX Needs docstring
     # XXX # TODO One day this signature should be generic, and not comfy specific
@@ -227,7 +227,7 @@ def horde_load_checkpoint(
     try:
         stdio = OutputCollector()
         with contextlib.redirect_stdout(stdio):
-            (modelPatcher, clipModel, vae, clipVisionModel) = __comfy_load_checkpoint_guess_config(
+            (modelPatcher, clipModel, vae, clipVisionModel) = _comfy_load_checkpoint_guess_config(
                 ckpt_path=ckpt_path,
                 output_vae=output_vae,
                 output_clip=output_clip,
@@ -249,7 +249,7 @@ def horde_load_controlnet(controlnet_path: str, target_model):  # XXX Needs docs
     # Redirect IO
     stdio = OutputCollector()
     with contextlib.redirect_stdout(stdio):
-        controlnet = __comfy_load_controlnet(ckpt_path=controlnet_path, model=target_model)
+        controlnet = _comfy_load_controlnet(ckpt_path=controlnet_path, model=target_model)
     return controlnet
 
 
@@ -316,22 +316,22 @@ class Comfy_Horde:
     def __init__(self) -> None:
         if _comfy_model_manager is None:
             raise RuntimeError("hordelib.initialise() must be called before using comfy_horde.")
-        self._client_id = {}
-        self._images = {}
-        self.pipelines = {}
-        self._model_locks = []
+        self._client_id = {}  # type: ignore
+        self._images = {}  # type: ignore
+        self.pipelines = {}  # type: ignore
+        self._model_locks = []  # type: ignore
         self._model_lock_mutex = threading.Lock()
         self._exit_time = 0
         self._callers = 0
         self._gc_timer = time.time()
         self._counter_mutex = threading.Lock()
         # FIXME Temporary hack to set the model dir for LORAs
-        _comfy_folder_paths["loras"] = (
+        _comfy_folder_paths["loras"] = (  # type: ignore
             [os.path.join(UserSettings.get_model_directory(), "loras")],
             [".safetensors"],
         )
         # Set custom node path
-        _comfy_folder_paths["custom_nodes"] = ([os.path.join(get_hordelib_path(), "nodes")], [])
+        _comfy_folder_paths["custom_nodes"] = ([os.path.join(get_hordelib_path(), "nodes")], [])  # type: ignore
         # Load our pipelines
         self._load_pipelines()
 
@@ -378,7 +378,7 @@ class Comfy_Horde:
         _comfy_nodes.init_custom_nodes()
 
     def _get_executor(self, pipeline):
-        executor = _comfy_PromptExecutor(self)
+        executor = _comfy_PromptExecutor(self)  # type: ignore
         return executor
 
     def get_pipeline_data(self, pipeline_name):
@@ -405,7 +405,7 @@ class Comfy_Horde:
                     if "inputs" in node and oldname in node["inputs"]:
                         node["inputs"][newname] = node["inputs"][oldname]
                         del node["inputs"][oldname]
-                logger.debug(f"Renamed node input {nodename}.{oldname} to {newname}")
+                logger.debug(f"Renamed node input {nodename}.{oldname} to {newname}")  # type: ignore # FIXME
 
         return data
 
@@ -558,6 +558,8 @@ class Comfy_Horde:
     # Execute the named pipeline and pass the pipeline the parameter provided.
     # For the horde we assume the pipeline returns an array of images.
     def _run_pipeline(self, pipeline: dict, params: dict) -> dict | None:
+        if _comfy_model_manager is None:
+            raise RuntimeError("hordelib.initialise() must be called before using comfy_horde.")
 
         # Update user settings
         _comfy_model_manager.set_user_reserved_vram(UserSettings.get_vram_to_leave_free_mb())
@@ -633,11 +635,11 @@ class Comfy_Horde:
 
         # We are being exited
         with self._counter_mutex:
-            self._exit_time = time.time()
+            self._exit_time = time.time()  # type: ignore
             self._callers -= 1
 
         if result:
-            return result
+            return result  # type: ignore
 
         return None
 

--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -2,6 +2,8 @@
 import os
 from enum import Enum, auto
 
+from strenum import StrEnum
+
 from hordelib.config_path import get_hordelib_path
 
 COMFYUI_VERSION = "84ea21c815d426000c233e0c7b8c542764335cc8"
@@ -25,22 +27,22 @@ class HordeSupportedBackends(Enum):
 EXCLUDED_MODEL_NAMES = ["pix2pix"]
 
 
-class MODEL_CATEGORY_NAMES(str, Enum):
+class MODEL_CATEGORY_NAMES(StrEnum):
     """Look up str enum for the categories of models (compvis, controlnet, clip, etc...)."""
 
-    default_models = "default_models"
+    default_models = auto()
     """Unspecified model category."""
-    codeformer = "codeformer"
-    compvis = "compvis"
+    codeformer = auto()
+    compvis = auto()
     """Stable Diffusion models."""
-    controlnet = "controlnet"
-    # diffusers = "diffusers"
-    esrgan = "esrgan"
-    gfpgan = "gfpgan"
-    safety_checker = "safety_checker"
-    lora = "lora"
-    blip = "blip"
-    clip = "clip"
+    controlnet = auto()
+    # diffusers = "auto()
+    esrgan = auto()
+    gfpgan = auto()
+    safety_checker = auto()
+    lora = auto()
+    blip = auto()
+    clip = auto()
 
 
 # Default model managers to load

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -319,7 +319,11 @@ class HordeLib:
                     if trigger_inject == "any":
                         triggers = SharedModelManager.manager.lora.get_lora_triggers(lora_name)
                         if triggers:
-                            trigger = triggers[0]
+                            trigger = random.choice(triggers)
+                    elif trigger_inject == "all":
+                        triggers = SharedModelManager.manager.lora.get_lora_triggers(lora_name)
+                        if triggers:
+                            trigger = ", ".join(triggers)
                     elif trigger_inject is not None:
                         trigger = SharedModelManager.manager.lora.find_lora_trigger(lora_name, trigger_inject)
                     if trigger:

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -1,5 +1,7 @@
 # horde.py
 # Main interface for the horde to this library.
+from __future__ import annotations
+
 import glob
 import json
 import os
@@ -19,7 +21,7 @@ from hordelib.utils.sanitizer import Sanitizer
 
 
 class HordeLib:
-    _instance = None
+    _instance: HordeLib | None = None
     _initialised = False
 
     # Horde to comfy sampler mapping
@@ -305,6 +307,8 @@ class HordeLib:
                 lora_name = SharedModelManager.manager.lora.get_lora_name(str(lora["name"]))
                 if lora_name:
                     logger.debug(f"Found valid lora {lora_name}")
+                    if SharedModelManager.manager.compvis is None:
+                        raise RuntimeError("Cannot use LORAs without a compvis loaded!")
                     model_details = SharedModelManager.manager.compvis.get_model(payload["model"])
                     # If the lora and model do not match baseline, we ignore the lora
                     if not SharedModelManager.manager.lora.do_baselines_match(lora_name, model_details):
@@ -518,14 +522,15 @@ class HordeLib:
         # Final adjustments to the pipeline
         pipeline_data = self.generator.get_pipeline_data(pipeline)
         payload = self._final_pipeline_adjustments(payload, pipeline_data)
+        models: list[str] = []
         # Run the pipeline
         try:
             # Add prefix to loras to avoid name collisions with other models
             models = [f"lora-{x['name']}" for x in payload.get("loras", []) if x]
             # main model
-            models.append(payload.get("model_loader.model_name"))
+            models.append(payload.get("model_loader.model_name"))  # type: ignore # FIXME?
             # controlnet model
-            models.append(payload.get("controlnet_model_loader.control_net_name"))
+            models.append(payload.get("controlnet_model_loader.control_net_name"))  # type: ignore # FIXME?
             # Acquire a lock on all these models
             self.lock_models(models)
             # Call the inference pipeline
@@ -560,7 +565,7 @@ class HordeLib:
         # Allow arbitrary resizing by shrinking the image back down
         if width or height:
             return ImageUtils.shrink_image(Image.open(images[0]["imagedata"]), width, height)
-        return self._process_results(images, rawpng)
+        return self._process_results(images, rawpng)  # type: ignore # FIXME?
 
     def image_facefix(self, payload, rawpng=False) -> Image.Image | None:
         # AIHorde hacks to payload
@@ -577,4 +582,4 @@ class HordeLib:
             images = self.generator.run_image_pipeline(pipeline_data, payload)
         finally:
             self.unlock_models([payload.get("model_loader.model_name")])
-        return self._process_results(images, rawpng)
+        return self._process_results(images, rawpng)  # type: ignore # FIXME?

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -792,6 +792,7 @@ class BaseModelManager(ABC):
                 else:
                     self.progress()
                     return False
+        return False
 
     def download_model(self, model_name: str):
         """

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -1,9 +1,10 @@
 import os
 import typing
-from enum import Enum
+from enum import auto
 from typing import Iterable
 
 from loguru import logger
+from strenum import StrEnum
 from typing_extensions import override
 
 from hordelib.comfy_horde import horde_load_controlnet
@@ -11,7 +12,7 @@ from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
 from hordelib.model_manager.base import BaseModelManager
 
 
-class CONTROLNET_BASELINE_NAMES(str, Enum):  # XXX # TODO Move this to consts.py
+class CONTROLNET_BASELINE_NAMES(StrEnum):  # XXX # TODO Move this to consts.py
     stable_diffusion_1 = "stable diffusion 1"
     stable_diffusion_2 = "stable diffusion 2"
 

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -315,7 +315,7 @@ class ModelManager:
                 return model_manager.unload_model(model_name)
         return None
 
-    def move_from_disk_cache(self, model_name, model, clip, vae):
+    def move_from_disk_cache(self, model_name, model, clip, vae) -> bool | None:
         """Moves the given model back into ram.
 
         Args:

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -77,7 +77,7 @@ class LoraModelManager(BaseModelManager):
             download_reference=download_reference,
         )
         # FIXME (shift lora.json handling into horde_model_reference?)
-        self.models_db_path = str(LEGACY_REFERENCE_FOLDER.joinpath("lora.json").resolve())
+        self.models_db_path = LEGACY_REFERENCE_FOLDER.joinpath("lora.json").resolve()
 
     def loadModelDatabase(self, list_models=False):
         if self.model_reference:

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -13,6 +13,8 @@ from enum import auto
 
 import requests
 from fuzzywuzzy import fuzz
+from horde_model_reference import LEGACY_REFERENCE_FOLDER
+from horde_model_reference.path_consts import get_model_reference_filename
 from loguru import logger
 from strenum import StrEnum
 from typing_extensions import override
@@ -74,6 +76,8 @@ class LoraModelManager(BaseModelManager):
             model_category_name=MODEL_CATEGORY_NAMES.lora,
             download_reference=download_reference,
         )
+        # FIXME (shift lora.json handling into horde_model_reference?)
+        self.models_db_path = str(LEGACY_REFERENCE_FOLDER.joinpath("lora.json").resolve())
 
     def loadModelDatabase(self, list_models=False):
         if self.model_reference:

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -9,11 +9,12 @@ import time
 import typing
 from collections import deque
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import auto
 
 import requests
 from fuzzywuzzy import fuzz
 from loguru import logger
+from strenum import StrEnum
 from typing_extensions import override
 
 from hordelib.consts import MODEL_CATEGORY_NAMES
@@ -21,17 +22,16 @@ from hordelib.model_manager.base import BaseModelManager
 from hordelib.utils.sanitizer import Sanitizer
 
 
-class DOWNLOAD_SIZE_CHECK(str, Enum):
-    everything = "everything"
-    top = "top"
-    adhoc = "adhoc"
+class DOWNLOAD_SIZE_CHECK(StrEnum):
+    everything = auto()
+    top = auto()
+    adhoc = auto()
 
 
 TESTS_ONGOING = os.getenv("TESTS_ONGOING", "0") == "1"
 
 
 class LoraModelManager(BaseModelManager):
-
     LORA_DEFAULTS = "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/lora.json"
     LORA_API = "https://civitai.com/api/v1/models?types=LORA&sort=Highest%20Rated&primaryFileOnly=true"
     MAX_RETRIES = 10 if not TESTS_ONGOING else 1
@@ -48,7 +48,6 @@ class LoraModelManager(BaseModelManager):
         allowed_adhoc_lora_storage=1024,
         download_wait=False,
     ):
-
         self._max_top_disk = allowed_top_lora_storage
 
         self.max_adhoc_disk = allowed_adhoc_lora_storage
@@ -366,6 +365,9 @@ class LoraModelManager(BaseModelManager):
 
     def _process_items(self):
         # i.e. given a bunch of LORA item metadata, download them
+        if not self._data:
+            logger.debug("No LORA data to process")
+            return
         for item in self._data.get("items", []):
             lora = self._parse_civitai_lora_data(item)
             if lora:
@@ -377,7 +379,6 @@ class LoraModelManager(BaseModelManager):
                 self._download_lora(lora)
 
     def _start_processing(self):
-
         self.stop_downloading = False
 
         while not self.stop_downloading:
@@ -562,7 +563,7 @@ class LoraModelManager(BaseModelManager):
             total_queue += lora["size_mb"]
         return total_queue
 
-    def find_oldest_adhoc_lora(self):
+    def find_oldest_adhoc_lora(self) -> str | None:
         oldest_lora: str | None = None
         oldest_datetime: datetime | None = None
         for lora in self._adhoc_loras:

--- a/hordelib/model_manager/safety_checker.py
+++ b/hordelib/model_manager/safety_checker.py
@@ -37,7 +37,7 @@ class SafetyCheckerModelManager(BaseModelManager):
         logger.info(f"Loading model {model_name} on {device}")
         logger.info(f"Model path: {self.modelFolderPath}")
         model = StableDiffusionSafetyChecker.from_pretrained(self.modelFolderPath)
-        model = model.eval()
+        model = model.eval()  # type: ignore # FIXME
         model.to(device)
         if half_precision:
             model = model.half()

--- a/hordelib/settings.py
+++ b/hordelib/settings.py
@@ -1,6 +1,7 @@
 import os
 import re
 from collections import deque
+from typing import Callable
 
 import psutil
 from typing_extensions import Self
@@ -53,7 +54,7 @@ class UserSettings:
     @staticmethod
     def _get_total_ram_mb() -> int:
         virtual_memory = psutil.virtual_memory()
-        return virtual_memory.total / (1024 * 1024)
+        return int(virtual_memory.total / (1024 * 1024))
 
     # Hordelib will try to leave at least this much VRAM free
 
@@ -158,7 +159,7 @@ class UserSettings:
     # Callback for use to broadcast download progress updates
     # Should be set to a method with a signature (description: str, current: int, total: int)
     # And will be called with a description of the download, current bytes and total bytes.
-    download_progress_callback = None
+    download_progress_callback: Callable[[str, int, int], None] | None = None
 
 
 _UserSettings = UserSettings()

--- a/hordelib/utils/distance.py
+++ b/hordelib/utils/distance.py
@@ -251,10 +251,10 @@ def get_hist(img: PIL.Image.Image) -> np.ndarray:
         img = img.convert("RGB")
 
     # Convert the image to a numpy array
-    img = np.array(img)
+    img_array = np.array(img)
 
     # Get the histogram of the image
-    hist = np.histogram(img, bins=DEFAULT_HISTOGRAM_BINS, range=DEFAULT_HISTOGRAM_RANGE)[0]
+    hist = np.histogram(img_array, bins=DEFAULT_HISTOGRAM_BINS, range=DEFAULT_HISTOGRAM_RANGE)[0]
 
     return hist
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,9 @@
 [mypy]
-exclude = (ComfyUI|comfy_controlnet_preprocessors|facerestore|comfy_horde|examples)
+exclude = (build|ComfyUI|comfy_controlnet_preprocessors|facerestore|comfy_horde\.py|examples|diffusers)
+
+[mypy-hordelib.nodes.comfy_controlnet_preprocessors.*]
+ignore_errors = True
+ignore_missing_imports = True
 
 [mypy-xformers.*]
 ignore_missing_imports = True
@@ -12,3 +16,25 @@ ignore_missing_imports = True
 
 [mypy-fuzzywuzzy.*]
 ignore_missing_imports = True
+
+[mypy-cv2.*]
+ignore_missing_imports = True
+
+[mypy-ComfyUI.*]
+ignore_missing_imports = True
+
+[mypy-comfy.*]
+ignore_missing_imports = True
+
+[mypy-execution.*]
+ignore_missing_imports = True
+
+[mypy-transformers.*]
+ignore_missing_imports = True
+
+[mypy-pynvml.smi.*]
+ignore_missing_imports = True
+
+[mypy-diffusers.*]
+ignore_missing_imports = True
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,9 @@ license-files = ["LICENSE", "CHANGELOG*"]
 dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.packages.find]
-exclude = ["ComfyUI", "build"]
+exclude = ["ComfyUI", "build", "tests"]
 namespaces = false
+
 
 [options.index-client]
 extra-index-urls = ["https://download.pytorch.org/whl/cu118"]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,10 @@
-tox>=4.4.11
-black==22.3.0
-pytest>=7.2.2
-coverage>=7.2.3
-ruff==0.0.261
+pytest==7.4.0
+mypy==1.4.1
+black==23.3.0
+ruff==0.0.275
+tox~=4.6.3
+pre-commit~=3.3.3
 build>=0.10.0
+coverage>=7.2.7
+
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ mediapipe>=0.9.1.0
 unidecode
 fuzzywuzzy
 horde_clipfree==0.0.2
+strenum

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from typing import Generator
 
 import PIL.Image
+from loguru import logger
 import pytest
 
 from hordelib.comfy_horde import Comfy_Horde
@@ -20,6 +21,7 @@ def init_horde():
     hordelib.initialise()
     from hordelib.settings import UserSettings
 
+    UserSettings.set_ram_to_leave_free_mb("100%")
     UserSettings.set_vram_to_leave_free_mb("90%")
 
 
@@ -50,20 +52,26 @@ def shared_model_manager(hordelib_instance: HordeLib) -> Generator[type[SharedMo
     assert SharedModelManager.manager.blip is not None
     assert SharedModelManager.manager.clip is not None
 
+    for model_availible in SharedModelManager.manager.compvis.get_loaded_models():
+        assert SharedModelManager.manager.unload_model(model_availible)
+
     yield SharedModelManager
 
     SharedModelManager._instance = None  # type: ignore
     SharedModelManager.manager = None  # type: ignore
 
 
+_testing_model_name = "Deliberate"
+
+
 @pytest.fixture(scope="class")
-def stable_diffusion_modelname_for_testing(shared_model_manager: type[SharedModelManager]) -> str:
+def stable_diffusion_model_name_for_testing(shared_model_manager: type[SharedModelManager]) -> str:
     """Loads the stable diffusion model for testing. This model is used by many tests.
     This fixture returns the model name as string."""
     shared_model_manager.load_model_managers([CompVisModelManager])
-    model_name = "Deliberate"
-    assert shared_model_manager.manager.load(model_name)
-    return model_name
+
+    assert shared_model_manager.manager.load(_testing_model_name)
+    return _testing_model_name
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 from typing import Generator
 
 import PIL.Image
-from loguru import logger
 import pytest
+from loguru import logger
 
 from hordelib.comfy_horde import Comfy_Horde
 from hordelib.horde import HordeLib

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 import PIL.Image
 import pytest
 
@@ -32,11 +34,11 @@ def isolated_comfy_horde_instance(init_horde) -> Comfy_Horde:
 
 
 @pytest.fixture(scope="class")
-def shared_model_manager(hordelib_instance: HordeLib) -> type[SharedModelManager]:
+def shared_model_manager(hordelib_instance: HordeLib) -> Generator[type[SharedModelManager], None, None]:
     SharedModelManager()
     SharedModelManager.load_model_managers(ALL_MODEL_MANAGER_TYPES)
 
-    assert SharedModelManager._instance is not None
+    assert SharedModelManager()._instance is not None
     assert SharedModelManager.manager is not None
     assert SharedModelManager.manager.codeformer is not None
     assert SharedModelManager.manager.compvis is not None
@@ -50,8 +52,8 @@ def shared_model_manager(hordelib_instance: HordeLib) -> type[SharedModelManager
 
     yield SharedModelManager
 
-    SharedModelManager._instance = None
-    SharedModelManager.manager = None
+    SharedModelManager._instance = None  # type: ignore
+    SharedModelManager.manager = None  # type: ignore
 
 
 @pytest.fixture(scope="class")
@@ -84,6 +86,7 @@ def pytest_collection_modifyitems(items):
     """Modifies test items to ensure test modules run in a given order."""
     MODULES_TO_RUN_FIRST = [
         "test_packaging_errors",
+        "tests.test_initialisation",
         "tests.test_cuda",
         "tests.test_utils",
         "tests.test_comfy_install",
@@ -93,6 +96,8 @@ def pytest_collection_modifyitems(items):
         "test_mm_lora",
     ]
     MODULES_TO_RUN_LAST = [
+        "test.test_blip",
+        "test.test_clip",
         "tests.test_inference",
         "tests.test_horde_inference",
         "tests.test_horde_inference_img2img",

--- a/tests/model_managers/test_mm_compvis.py
+++ b/tests/model_managers/test_mm_compvis.py
@@ -1,3 +1,5 @@
+from typing import Generator
+
 import pytest
 
 import hordelib
@@ -6,7 +8,7 @@ from hordelib.model_manager.compvis import CompVisModelManager
 
 class TestCompvis:
     @pytest.fixture(scope="class", autouse=True)
-    def compvis_model_manager(self, init_horde) -> CompVisModelManager:
+    def compvis_model_manager(self, init_horde) -> Generator[CompVisModelManager, None, None]:
         yield CompVisModelManager()
 
     def test_compvis_load_defaults(self, compvis_model_manager):

--- a/tests/model_managers/test_shared_model_manager.py
+++ b/tests/model_managers/test_shared_model_manager.py
@@ -1,4 +1,6 @@
 # test_horde.py
+import os
+
 import pytest
 
 from hordelib.consts import EXCLUDED_MODEL_NAMES, MODEL_CATEGORY_NAMES
@@ -15,7 +17,7 @@ class TestSharedModelManager:
         self,
         shared_model_manager: type[SharedModelManager],
     ):
-        _shared_test_singleton = None if shared_model_manager._instance is None else SharedModelManager._instance
+        _shared_test_singleton = None if shared_model_manager._instance is None else SharedModelManager()._instance
         a = SharedModelManager()
         b = SharedModelManager()
         assert a.manager is b.manager
@@ -115,6 +117,13 @@ class TestSharedModelManager:
         self,
         shared_model_manager: type[SharedModelManager],
     ):
+        if os.environ.get("TESTS_ONGOING"):
+            pytest.skip(
+                (
+                    "Skipping test_check_validate_all_available_models because it takes too long and could tamper "
+                    "with CI environment."
+                ),
+            )
         assert shared_model_manager.manager is not None
         for model_manager in shared_model_manager.manager.active_model_managers:
             for model in model_manager.available_models:

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,6 +1,6 @@
 # test_horde.py
 import pytest
-from PIL import Image
+from PIL.Image import Image
 
 from hordelib.clip.interrogate import Interrogator
 from hordelib.horde import HordeLib
@@ -34,6 +34,8 @@ class TestHordeClip:
             text_array=word_list,
             similarity=True,
         )
+
+        assert type(similarity_result) is dict
         assert "default" in similarity_result
         assert similarity_result["default"]["outlaw"] > 0.15
         assert similarity_result["default"]["explosion"] > 0.15

--- a/tests/test_comfy.py
+++ b/tests/test_comfy.py
@@ -46,6 +46,17 @@ class TestSetup:
             "unknown.parameter": False,
         }
         hordelib_instance.generator._set(test_dict, **params)
+
+        assert "a" in test_dict and type(test_dict["a"]) is dict
+        assert "inputs" in test_dict["a"]
+        assert "b" in test_dict["a"]["inputs"]
+        assert "c" in test_dict
+        assert type(test_dict["c"]) is dict
+        assert "inputs" in test_dict["c"]
+        assert "d" in test_dict["c"]["inputs"]
+        assert "e" in test_dict["c"]["inputs"]["d"]
+        assert "f" in test_dict["c"]["inputs"]["d"]
+
         assert test_dict["a"]["inputs"]["b"]
         assert test_dict["c"]["inputs"]["d"]["e"]
         assert test_dict["c"]["inputs"]["d"]["f"]
@@ -103,6 +114,24 @@ class TestSetup:
         }
         data = hordelib_instance.generator._fix_node_names(data, design)
 
+        assert data
+        assert type(data) is dict
+
+        assert "Node1" in data
+        assert "inputs" in data["Node1"] and type(data["Node1"]["inputs"]) is dict
+        assert "input1" in data["Node1"]["inputs"] and type(data["Node1"]["inputs"]["input1"]) is list
+        assert "input2" in data["Node1"]["inputs"] and type(data["Node1"]["inputs"]["input2"]) is list
+
+        assert "Node2" in data
+        assert "inputs" in data["Node2"] and type(data["Node2"]["inputs"]) is dict
+        assert "input1" in data["Node2"]["inputs"] and type(data["Node2"]["inputs"]["input1"]) is list
+        assert "input2" in data["Node2"]["inputs"] and type(data["Node2"]["inputs"]["input2"]) is list
+
+        assert "3" in data
+        assert "inputs" in data["3"] and type(data["3"]["inputs"]) is dict
+        assert "input1" in data["3"]["inputs"] and type(data["3"]["inputs"]["input1"]) is list
+        assert "input2" in data["3"]["inputs"] and type(data["3"]["inputs"]["input2"]) is list
+
         assert "Node1" in data
         assert data["Node1"]["inputs"]["input1"][0] == "Node2"
         assert data["Node1"]["inputs"]["input2"][0] == "3"
@@ -145,6 +174,13 @@ class TestSetup:
         result = hordelib_instance.generator.reconnect_input(data, "sampler.latent_image", "vae_encoder")
         # Should be ok
         assert result
+
+        assert "sampler" in data
+        assert "inputs" in data["sampler"]
+        assert "latent_image" in data["sampler"]["inputs"]
+        assert type(data["sampler"]["inputs"]) is dict
+        assert type(data["sampler"]["inputs"]["latent_image"]) is list
+
         assert data["sampler"]["inputs"]["latent_image"][0] == "vae_encoder"
         # This is invalid
         result = hordelib_instance.generator.reconnect_input(data, "sampler.non-existant", "somewhere")

--- a/tests/test_horde_inference.py
+++ b/tests/test_horde_inference.py
@@ -14,7 +14,7 @@ class TestHordeInference:
     def test_text_to_image(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -33,10 +33,11 @@ class TestHordeInference:
             "prompt": "an ancient llamia monster",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "text_to_image.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -49,7 +50,7 @@ class TestHordeInference:
     def test_text_to_image_small(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -68,10 +69,11 @@ class TestHordeInference:
             "prompt": "a photo of cute dinosaur ### painting, drawing, artwork, red border",
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "text_to_image_small.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -84,7 +86,7 @@ class TestHordeInference:
     def test_text_to_image_clip_skip_2(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -103,10 +105,11 @@ class TestHordeInference:
             "prompt": "an ancient llamia monster",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "text_to_image_clip_skip_2.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -119,7 +122,7 @@ class TestHordeInference:
     def test_text_to_image_hires_fix(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -138,10 +141,11 @@ class TestHordeInference:
             "prompt": "an ancient llamia monster",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "text_to_image_hires_fix.png"
         pil_image.save(f"images/{img_filename}", quality=100)

--- a/tests/test_horde_inference_controlnet.py
+++ b/tests/test_horde_inference_controlnet.py
@@ -13,6 +13,7 @@ from .testing_shared_functions import check_single_inference_image_similarity
 class TestHordeInference:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self, shared_model_manager: type[SharedModelManager]):
+        assert shared_model_manager.manager.controlnet is not None
         for preproc in HordeLib.CONTROLNET_IMAGE_PREPROCESSOR_MAP.keys():
             shared_model_manager.manager.controlnet.download_control_type(preproc, ["stable diffusion 1"])
 
@@ -44,6 +45,8 @@ class TestHordeInference:
             "source_processing": "img2img",
         }
         assert hordelib_instance is not None
+        assert shared_model_manager.manager.controlnet is not None
+
         images_to_compare: list[tuple[str, Image.Image]] = []
         for preproc in HordeLib.CONTROLNET_IMAGE_PREPROCESSOR_MAP.keys():
             if preproc == "scribble" or preproc == "mlsd":
@@ -62,6 +65,8 @@ class TestHordeInference:
             assert pil_image is not None
 
             img_filename = f"controlnet_{preproc}.png"
+
+            assert isinstance(pil_image, Image.Image)
 
             pil_image.save(f"images/{img_filename}", quality=100)
             images_to_compare.append((f"images_expected/{img_filename}", pil_image))
@@ -138,6 +143,8 @@ class TestHordeInference:
 
             img_filename = f"controlnet_strength_{strength}.png"
 
+            assert isinstance(pil_image, Image.Image)
+
             pil_image.save(f"images/{img_filename}", quality=100)
             images_to_compare.append((f"images_expected/{img_filename}", pil_image))
 
@@ -183,6 +190,8 @@ class TestHordeInference:
 
             img_filename = f"controlnet_hires_fix_denoise_{denoise}.png"
 
+            assert isinstance(pil_image, Image.Image)
+
             pil_image.save(f"images/{img_filename}", quality=100)
             images_to_compare.append((f"images_expected/{img_filename}", pil_image))
 
@@ -218,6 +227,8 @@ class TestHordeInference:
         assert pil_image is not None
 
         img_filename = "controlnet_image_is_control.png"
+
+        assert isinstance(pil_image, Image.Image)
 
         pil_image.save(f"images/{img_filename}", quality=100)
         images_to_compare.append((f"images_expected/{img_filename}", pil_image))

--- a/tests/test_horde_inference_controlnet.py
+++ b/tests/test_horde_inference_controlnet.py
@@ -21,7 +21,7 @@ class TestHordeInference:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -40,7 +40,7 @@ class TestHordeInference:
             "prompt": "a man walking in the snow",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
@@ -80,7 +80,7 @@ class TestHordeInference:
     def test_controlnet_fake_cn(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         db0_test_image: Image.Image,
     ):
         data = {
@@ -100,7 +100,7 @@ class TestHordeInference:
             "prompt": "a man walking in the snow",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": db0_test_image,
             "source_processing": "img2img",
         }
@@ -111,7 +111,7 @@ class TestHordeInference:
     def test_controlnet_strength(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -130,7 +130,7 @@ class TestHordeInference:
             "prompt": "a man walking on the moon",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
@@ -157,7 +157,7 @@ class TestHordeInference:
     def test_controlnet_hires_fix(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -177,7 +177,7 @@ class TestHordeInference:
             "prompt": "a man walking in the jungle",
             "ddim_steps": 15,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
@@ -198,7 +198,7 @@ class TestHordeInference:
     def test_controlnet_image_is_control(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -217,7 +217,7 @@ class TestHordeInference:
             "prompt": "a woman standing in the snow",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_image_is_control.png"),
             "source_processing": "img2img",
         }

--- a/tests/test_horde_inference_img2img.py
+++ b/tests/test_horde_inference_img2img.py
@@ -13,7 +13,7 @@ from .testing_shared_functions import check_single_inference_image_similarity
 class TestHordeInference:
     def test_image_to_image(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -33,7 +33,7 @@ class TestHordeInference:
             "prompt": "a dinosaur",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
@@ -51,7 +51,7 @@ class TestHordeInference:
 
     def test_image_to_image_hires_fix_small(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -71,7 +71,7 @@ class TestHordeInference:
             "prompt": "a dinosaur",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
@@ -89,7 +89,7 @@ class TestHordeInference:
 
     def test_image_to_image_hires_fix_large(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -109,7 +109,7 @@ class TestHordeInference:
             "prompt": "a dinosaur",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
@@ -126,7 +126,7 @@ class TestHordeInference:
 
     def test_img2img_masked_denoise_1(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -141,7 +141,7 @@ class TestHordeInference:
             "prompt": "a mecha robot sitting on a bench",
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_img2img_alpha.png"),
             "source_processing": "img2img",
         }
@@ -159,7 +159,7 @@ class TestHordeInference:
 
     def test_img2img_masked_denoise_high(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -174,7 +174,7 @@ class TestHordeInference:
             "prompt": "a mecha robot sitting on a bench",
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_img2img_alpha.png"),
             "source_processing": "img2img",
         }
@@ -192,7 +192,7 @@ class TestHordeInference:
 
     def test_img2img_masked_denoise_mid(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -207,7 +207,7 @@ class TestHordeInference:
             "prompt": "a mecha robot sitting on a bench",
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_img2img_alpha.png"),
             "source_processing": "img2img",
         }
@@ -225,7 +225,7 @@ class TestHordeInference:
 
     def test_img2img_masked_denoise_low(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -240,7 +240,7 @@ class TestHordeInference:
             "prompt": "a mecha robot sitting on a bench",
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": Image.open("images/test_img2img_alpha.png"),
             "source_processing": "img2img",
         }
@@ -258,7 +258,7 @@ class TestHordeInference:
 
     def test_image_to_faulty_source_image(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -278,7 +278,7 @@ class TestHordeInference:
             "prompt": "an ancient llamia monster",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
             "source_image": "THIS SHOULD FAILOVER TO TEXT2IMG",
             "source_processing": "img2img",
         }

--- a/tests/test_horde_inference_img2img.py
+++ b/tests/test_horde_inference_img2img.py
@@ -39,6 +39,7 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (512, 512)
 
         img_filename = "image_to_image.png"
@@ -77,6 +78,7 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (512, 512)
 
         img_filename = "image_to_image_hires_fix_small.png"
@@ -116,6 +118,7 @@ class TestHordeInference:
         assert hordelib_instance is not None
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (768, 768)
         img_filename = "image_to_image_hires_fix_large.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -147,6 +150,7 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (512, 512)
 
         img_filename = "img2img_to_masked_denoise_1.png"
@@ -180,6 +184,7 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (512, 512)
 
         img_filename = "img2img_to_masked_denoise_0.6.png"
@@ -213,6 +218,7 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (512, 512)
 
         img_filename = "img2img_to_masked_denoise_0.4.png"
@@ -246,6 +252,7 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (512, 512)
 
         img_filename = "img2img_to_masked_denoise_0.2.png"
@@ -284,6 +291,7 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "img2img_fallback_to_txt2img.png"
         pil_image.save(f"images/{img_filename}", quality=100)

--- a/tests/test_horde_inference_painting.py
+++ b/tests/test_horde_inference_painting.py
@@ -1,4 +1,5 @@
 import os
+from typing import Generator
 
 import pytest
 from PIL import Image
@@ -11,11 +12,16 @@ from .testing_shared_functions import check_single_inference_image_similarity
 
 class TestHordeInference:
     @pytest.fixture(scope="class")
-    def inpainting_model_for_testing(self, shared_model_manager: type[SharedModelManager]) -> str:
+    def inpainting_model_for_testing(
+        self,
+        shared_model_manager: type[SharedModelManager],
+    ) -> Generator[str, None, None]:
         """Loads the inpainting model for testing.
         This fixture returns the (str) model name."""
         model_name = "Deliberate Inpainting"
-        assert shared_model_manager.manager.load(model_name)
+        if not shared_model_manager.manager.load(model_name):
+            shared_model_manager.manager.download_model(model_name)
+            assert shared_model_manager.manager.load(model_name)
         yield model_name
         assert shared_model_manager.manager.unload_model(model_name)
 
@@ -49,6 +55,9 @@ class TestHordeInference:
         assert pil_image is not None
 
         img_filename = "inpainting_mask_alpha.png"
+
+        assert isinstance(pil_image, Image.Image)
+
         pil_image.save(f"images/{img_filename}", quality=100)
 
         assert check_single_inference_image_similarity(
@@ -87,6 +96,9 @@ class TestHordeInference:
         assert pil_image is not None
 
         img_filename = "inpainting_mask_separate.png"
+
+        assert isinstance(pil_image, Image.Image)
+
         pil_image.save(f"images/{img_filename}", quality=100)
 
         assert check_single_inference_image_similarity(
@@ -122,6 +134,9 @@ class TestHordeInference:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+
+        assert isinstance(pil_image, Image.Image)
+
         assert pil_image.size == (512, 512)
 
         img_filename = "inpainting_mountains.png"
@@ -159,10 +174,13 @@ class TestHordeInference:
             "source_processing": "outpainting",
         }
         pil_image = hordelib_instance.basic_inference(data)
+
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
         assert pil_image.size == (512, 512)
 
         img_filename = "outpainting_mountains.png"
+
         pil_image.save(f"images/{img_filename}", quality=100)
 
         assert check_single_inference_image_similarity(

--- a/tests/test_horde_lora.py
+++ b/tests/test_horde_lora.py
@@ -417,3 +417,69 @@ class TestHordeLora:
             f"images_expected/{img_filename}",
             pil_image,
         )
+
+    def test_negative_model_power(
+        self,
+        hordelib_instance: HordeLib,
+        stable_diffusion_modelname_for_testing: str,
+    ):
+
+        lora_name = "58390"
+        data = {
+            "sampler_name": "k_euler",
+            "cfg_scale": 8.0,
+            "denoising_strength": 1.0,
+            "seed": 1312,
+            "height": 512,
+            "width": 512,
+            "karras": False,
+            "tiling": False,
+            "hires_fix": False,
+            "clip_skip": 1,
+            "control_type": None,
+            "image_is_control": False,
+            "return_control_map": False,
+            "prompt": "A girl walking in a field of flowers",
+            "loras": [{"name": lora_name, "model": -2.0, "clip": 1.0}],
+            "ddim_steps": 20,
+            "n_iter": 1,
+            "model": stable_diffusion_modelname_for_testing,
+        }
+
+        pil_image = hordelib_instance.basic_inference(data)
+        assert pil_image is not None
+
+        img_filename = "lora_negative_strength.png"
+        pil_image.save(f"images/{img_filename}", quality=100)
+
+        data = {
+            "sampler_name": "k_euler",
+            "cfg_scale": 8.0,
+            "denoising_strength": 1.0,
+            "seed": 1312,
+            "height": 512,
+            "width": 512,
+            "karras": False,
+            "tiling": False,
+            "hires_fix": False,
+            "clip_skip": 1,
+            "control_type": None,
+            "image_is_control": False,
+            "return_control_map": False,
+            "prompt": "A girl walking in a field of flowers",
+            "loras": [{"name": lora_name, "model": 2.0, "clip": 1.0}],
+            "ddim_steps": 20,
+            "n_iter": 1,
+            "model": stable_diffusion_modelname_for_testing,
+        }
+
+        pil_image = hordelib_instance.basic_inference(data)
+        assert pil_image is not None
+
+        img_filename = "lora_positive_strength.png"
+        pil_image.save(f"images/{img_filename}", quality=100)
+
+        # assert check_single_lora_image_similarity(
+        #     f"images_expected/{img_filename}",
+        #     pil_image,
+        # )

--- a/tests/test_horde_lora.py
+++ b/tests/test_horde_lora.py
@@ -24,7 +24,7 @@ class TestHordeLora:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         assert shared_model_manager.manager.lora
 
@@ -50,7 +50,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": 1.0, "clip": 1.0}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
@@ -72,7 +72,7 @@ class TestHordeLora:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         assert shared_model_manager.manager.lora
 
@@ -98,7 +98,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": 1.0, "clip": 1.0}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -117,7 +117,7 @@ class TestHordeLora:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         assert shared_model_manager.manager.lora
 
@@ -150,7 +150,7 @@ class TestHordeLora:
             ],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -169,7 +169,7 @@ class TestHordeLora:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         assert shared_model_manager.manager.lora
 
@@ -200,7 +200,7 @@ class TestHordeLora:
             ],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -211,7 +211,7 @@ class TestHordeLora:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         assert shared_model_manager.manager.lora
 
@@ -235,7 +235,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": 1.0, "clip": 1.0, "inject_trigger": "red"}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -254,7 +254,7 @@ class TestHordeLora:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         assert shared_model_manager.manager.lora
 
@@ -278,7 +278,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": 1.0, "clip": 1.0, "inject_trigger": "any"}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -297,7 +297,7 @@ class TestHordeLora:
         self,
         shared_model_manager: type[SharedModelManager],
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         assert shared_model_manager.manager.lora
 
@@ -322,7 +322,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": 0.75, "clip": 1.0, "inject_trigger": "any"}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -339,7 +339,7 @@ class TestHordeLora:
     def test_for_probability_tensor_runtime_error(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_euler",
@@ -364,7 +364,7 @@ class TestHordeLora:
             ],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -373,7 +373,7 @@ class TestHordeLora:
     def test_sd21_lora_against_sd15_model(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_euler",
@@ -396,7 +396,7 @@ class TestHordeLora:
             ],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -405,7 +405,7 @@ class TestHordeLora:
     def test_stonepunk(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         # Blue, fuzzy search on version
         lora_name = "51539"
@@ -427,7 +427,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": 1.0, "clip": 1.0, "inject_trigger": "any"}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)

--- a/tests/test_horde_lora.py
+++ b/tests/test_horde_lora.py
@@ -447,7 +447,6 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
-
         lora_name = "58390"
         data = {
             "sampler_name": "k_euler",
@@ -472,6 +471,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_negative_strength.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -499,6 +499,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_positive_strength.png"
         pil_image.save(f"images/{img_filename}", quality=100)

--- a/tests/test_horde_lora.py
+++ b/tests/test_horde_lora.py
@@ -14,6 +14,7 @@ from .testing_shared_functions import check_single_lora_image_similarity
 class TestHordeLora:
     @pytest.fixture(autouse=True, scope="class")
     def setup_and_teardown(self, shared_model_manager: type[SharedModelManager]):
+        assert shared_model_manager.manager.lora
         shared_model_manager.manager.lora.download_default_loras()
         shared_model_manager.manager.lora.wait_for_downloads()
         yield
@@ -25,9 +26,11 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
+        assert shared_model_manager.manager.lora
 
         # Red
         lora_name = shared_model_manager.manager.lora.get_lora_name("GlowingRunesAI")
+        assert isinstance(lora_name, str)
         trigger = shared_model_manager.manager.lora.find_lora_trigger(lora_name, "red")
         data = {
             "sampler_name": "k_euler",
@@ -51,6 +54,7 @@ class TestHordeLora:
         }
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_red.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -60,9 +64,9 @@ class TestHordeLora:
             pil_image,
         )
 
-        assert shared_model_manager.manager.lora.get_lora_last_use("GlowingRunesAI") > datetime.now() - timedelta(
-            minutes=1,
-        )
+        last_use = shared_model_manager.manager.lora.get_lora_last_use("GlowingRunesAI")
+        assert last_use
+        assert last_use > datetime.now() - timedelta(minutes=1)
 
     def test_text_to_image_lora_blue(
         self,
@@ -70,8 +74,11 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
+        assert shared_model_manager.manager.lora
+
         # Blue, fuzzy search on version
         lora_name = shared_model_manager.manager.lora.get_lora_name("GlowingRunesAI")
+        assert lora_name
         trigger = shared_model_manager.manager.lora.find_lora_trigger(lora_name, "blue")
         data = {
             "sampler_name": "k_euler",
@@ -96,6 +103,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_blue.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -111,7 +119,10 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
+        assert shared_model_manager.manager.lora
+
         lora_name = shared_model_manager.manager.lora.get_lora_name("GlowingRunesAI")
+        assert isinstance(lora_name, str)
         trigger = shared_model_manager.manager.lora.find_lora_trigger(lora_name, "red")
         trigger2 = shared_model_manager.manager.lora.find_lora_trigger(lora_name, "blue")
         lora_name2 = shared_model_manager.manager.lora.get_lora_name("Dra9onScaleAI")
@@ -144,6 +155,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_multiple.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -159,7 +171,10 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
+        assert shared_model_manager.manager.lora
+
         lora_name = shared_model_manager.manager.lora.get_lora_name("GlowingRunesAI")
+        assert isinstance(lora_name, str)
         trigger = shared_model_manager.manager.lora.find_lora_trigger(lora_name, "blue")
         lora_name2 = shared_model_manager.manager.lora.get_lora_name("Dra9onScaleAI")
         trigger2 = shared_model_manager.manager.lora.find_lora_trigger(lora_name, "Dr490nSc4leAI")
@@ -198,6 +213,8 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
+        assert shared_model_manager.manager.lora
+
         # Red
         lora_name = shared_model_manager.manager.lora.get_lora_name("GlowingRunesAI")
         data = {
@@ -223,6 +240,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_inject_red.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -238,6 +256,8 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
+        assert shared_model_manager.manager.lora
+
         # Red
         lora_name = shared_model_manager.manager.lora.get_lora_name("GlowingRunesAI")
         data = {
@@ -263,6 +283,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_inject_any.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -278,6 +299,8 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
+        assert shared_model_manager.manager.lora
+
         lora_name = "74384"
         shared_model_manager.manager.lora.ensure_lora_deleted(lora_name)
         data = {
@@ -304,6 +327,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_download_adhoc.png"
         pil_image.save(f"images/{img_filename}", quality=100)
@@ -383,7 +407,6 @@ class TestHordeLora:
         hordelib_instance: HordeLib,
         stable_diffusion_modelname_for_testing: str,
     ):
-
         # Blue, fuzzy search on version
         lora_name = "51539"
         data = {
@@ -409,6 +432,7 @@ class TestHordeLora:
 
         pil_image = hordelib_instance.basic_inference(data)
         assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
         img_filename = "lora_stonepunk.png"
         pil_image.save(f"images/{img_filename}", quality=100)

--- a/tests/test_horde_lora.py
+++ b/tests/test_horde_lora.py
@@ -445,7 +445,7 @@ class TestHordeLora:
     def test_negative_model_power(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         lora_name = "58390"
         data = {
@@ -466,7 +466,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": -2.0, "clip": 1.0}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)
@@ -494,7 +494,7 @@ class TestHordeLora:
             "loras": [{"name": lora_name, "model": 2.0, "clip": 1.0}],
             "ddim_steps": 20,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         pil_image = hordelib_instance.basic_inference(data)

--- a/tests/test_horde_pp.py
+++ b/tests/test_horde_pp.py
@@ -59,10 +59,10 @@ class TestHordeUpscaling:
         model_name: str,
         image_filename: str,
         target_image: PIL.Image.Image,
-        expected_scale_factor: int,
-        custom_data: dict = None,
-        post_process_function: typing.Callable[[dict], PIL.Image.Image] = None,
-        similarity_constraints: ImageSimilarityConstraints = None,
+        expected_scale_factor: float,
+        custom_data: dict | None = None,
+        post_process_function: typing.Callable[[dict], PIL.Image.Image | None],
+        similarity_constraints: ImageSimilarityConstraints | None = None,
     ):
 
         if similarity_constraints is None:
@@ -94,6 +94,7 @@ class TestHordeUpscaling:
         )
 
         assert cls.shared_model_manager.manager.unload_model(model_name)
+        assert cls.shared_model_manager.manager.esrgan
         assert cls.shared_model_manager.manager.esrgan.is_model_loaded(model_name) is False
 
         # It is important this is done after the model is unloaded, otherwise if a skip occurs

--- a/tests/test_horde_samplers.py
+++ b/tests/test_horde_samplers.py
@@ -14,7 +14,7 @@ SLOW_SAMPLERS = ["k_dpmpp_2s_a", "k_dpmpp_sde", "k_heun", "k_dpm_2", "k_dpm_2_a"
 class TestHordeSamplers:
     def test_samplers(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -38,7 +38,7 @@ class TestHordeSamplers:
             ),
             "ddim_steps": 30,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
         images_to_compare: list[tuple[str, Image.Image]] = []
         for sampler in HordeLib.SAMPLERS_MAP.keys():
@@ -59,7 +59,7 @@ class TestHordeSamplers:
 
     def test_slow_samplers(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         hordelib_instance: HordeLib,
     ):
         data = {
@@ -83,7 +83,7 @@ class TestHordeSamplers:
             ),
             "ddim_steps": 10,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
 
         images_to_compare: list[tuple[str, Image.Image]] = []

--- a/tests/test_image_metadata.py
+++ b/tests/test_image_metadata.py
@@ -12,7 +12,7 @@ class TestHordeInference:
     def test_text_to_image(
         self,
         hordelib_instance: HordeLib,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
     ):
         data = {
             "sampler_name": "k_dpmpp_2m",
@@ -31,7 +31,7 @@ class TestHordeInference:
             "prompt": "a secret metadata store",
             "ddim_steps": 25,
             "n_iter": 1,
-            "model": stable_diffusion_modelname_for_testing,
+            "model": stable_diffusion_model_name_for_testing,
         }
         png_data = hordelib_instance.basic_inference(data, rawpng=True)
         assert png_data is not None

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -17,7 +17,7 @@ class TestInference:
 
     def test_stable_diffusion_pipeline(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         shared_model_manager: type[SharedModelManager],
         isolated_comfy_horde_instance: Comfy_Horde,
     ):
@@ -33,7 +33,7 @@ class TestInference:
             "sampler.steps": 25,
             "prompt.text": "a closeup photo of a confused dog",
             "negative_prompt.text": "cat, black and white, deformed",
-            "model_loader.model_name": stable_diffusion_modelname_for_testing,
+            "model_loader.model_name": stable_diffusion_model_name_for_testing,
             "clip_skip.stop_at_clip_layer": -1,
             "model_loader.model_manager": shared_model_manager,
         }
@@ -50,7 +50,7 @@ class TestInference:
 
     def test_stable_diffusion_pipeline_clip_skip(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         shared_model_manager: type[SharedModelManager],
         isolated_comfy_horde_instance: Comfy_Horde,
     ):
@@ -66,7 +66,7 @@ class TestInference:
             "sampler.steps": 25,
             "prompt.text": "a closeup photo of a confused dog",
             "negative_prompt.text": "cat, black and white, deformed",
-            "model_loader.model_name": stable_diffusion_modelname_for_testing,
+            "model_loader.model_name": stable_diffusion_model_name_for_testing,
             "clip_skip.stop_at_clip_layer": -2,
             "model_loader.model_manager": shared_model_manager,
         }
@@ -83,7 +83,7 @@ class TestInference:
 
     def test_stable_diffusion_hires_fix_pipeline(
         self,
-        stable_diffusion_modelname_for_testing: str,
+        stable_diffusion_model_name_for_testing: str,
         shared_model_manager: type[SharedModelManager],
         isolated_comfy_horde_instance: Comfy_Horde,
     ):
@@ -103,7 +103,7 @@ class TestInference:
             "negative_prompt.text": (
                 "render, cg, drawing, painting, artist, graphics, deformed, black and white, deformed eyes"
             ),
-            "model_loader.model_name": stable_diffusion_modelname_for_testing,
+            "model_loader.model_name": stable_diffusion_model_name_for_testing,
             "model_loader.model_manager": shared_model_manager,
             "empty_latent_image.width": 512,
             "empty_latent_image.height": 512,

--- a/tests/test_payload_mapping.py
+++ b/tests/test_payload_mapping.py
@@ -43,6 +43,7 @@ class TestPayloadMapping:
         result = data.copy()
         result = hordelib_instance._validate_data_structure(result)
         assert "loras" in result, "Lost the lora attribute in our payload"
+        assert isinstance(result["loras"], list), "Lora attribute is not a list"
         assert len(result["loras"]) == 1, "Unexpected number of loras in payload"
         assert result["loras"][0]["name"] == "briscou's gingers", "We lost Briscou's gingers"
         assert result["loras"][0]["model"] == 0.5, "Unexpected lora model weight"

--- a/tests/test_safety_checker.py
+++ b/tests/test_safety_checker.py
@@ -16,6 +16,7 @@ class TestHordeSaftyChecker:
         db0_test_image: Image.Image,
     ):
         assert shared_model_manager.manager.load("safety_checker", cpu_only=True)
+        assert shared_model_manager.manager.safety_checker
         assert shared_model_manager.manager.safety_checker.is_model_loaded("safety_checker") is True
         assert is_image_nsfw(db0_test_image) is False
         assert shared_model_manager.manager.unload_model("safety_checker")
@@ -25,6 +26,7 @@ class TestHordeSaftyChecker:
         shared_model_manager: type[SharedModelManager],
         db0_test_image: Image.Image,
     ):
+        assert shared_model_manager.manager.safety_checker
         assert shared_model_manager.manager.safety_checker.is_model_loaded("safety_checker") is False
         assert is_image_nsfw(db0_test_image) is False
         assert shared_model_manager.manager.unload_model("safety_checker")

--- a/tests/testing_shared_functions.py
+++ b/tests/testing_shared_functions.py
@@ -2,15 +2,17 @@ import json
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from typing import Iterable, TypeVar
+from typing import Iterable, TypeAlias
 
 import PIL.Image
 import pytest
 
-FilePathOrPILImage = TypeVar("FilePathOrPILImage", str, Path, PIL.Image.Image)
+FilePathOrPILImage: TypeAlias = str | Path | PIL.Image.Image
 
 from hordelib.utils.distance import (
+    CosineSimilarityResult,
     CosineSimilarityResultCode,
+    HistogramDistanceResult,
     HistogramDistanceResultCode,
     evaluate_image_distance,
     is_cosine_similarity_fail,
@@ -55,8 +57,8 @@ class ImageSimilarityResultCode(Enum):
 @dataclass
 class ImageSimilarityResult:
     result_code: ImageSimilarityResultCode
-    cosine_similarity_result: CosineSimilarityResultCode | float
-    histogram_distance_result: HistogramDistanceResultCode | float
+    cosine_similarity_result: CosineSimilarityResult | float
+    histogram_distance_result: HistogramDistanceResult | float
 
 
 def check_image_similarity_pytest(

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,7 @@ deps =
     loguru
     typing-extensions
     psutil
+    strenum
     # NOTE: If you are here because this test fails, 
     # - include the imports missing (check the exception thrown) here 
     # - **and** in the appropriate place in `release.yaml`.


### PR DESCRIPTION
fix: lora.json in site-packages:
- See #57 

feat: python 3.11 support
- The use of the idiom `class classname(str, Enum)` has been replaced with the strenum package, to support both python 3.10 + 3.11.
- These enum classes now use `auto()`

refactor: code cleanup + mypy compliance
- Many potentially unset or unbound variables now handled explictly
- Certain corner cases errors now still occur, but with context as for why.
- Numerous type hints corrected or made more accurate
- Several `# type: ignore` mypy meta-commands are present. Any outside `comfy_horde.py` are probably in need of some attention.