### PR TITLE
fix: TI now correctly compares to intended sha256 from hordeling

### DIFF
--- a/hordelib/model_manager/ti.py
+++ b/hordelib/model_manager/ti.py
@@ -279,9 +279,9 @@ class TextualInversionModelManager(BaseModelManager):
                         )
                     else:
                         hordeling_json = hordeling_response.json()
+                        if hordeling_json.get("sha256"):
+                            ti["sha256"] = hordeling_json["sha256"]
                         if os.path.exists(filepath) and os.path.exists(hashpath):
-                            if hordeling_json.get("sha256"):
-                                ti["sha256"] = hordeling_json["sha256"]
                             # Check the hash
                             with open(hashpath) as infile:
                                 try:


### PR DESCRIPTION
A simple control scope issue led to the wrong SHA being considered when confirming the integretity of safetensors files downloaded from hordeling.