### PR TITLE
feat: graceful fail if we detect a login redirect from civitai for loras

### DIFF
--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -333,6 +333,9 @@ class LoraModelManager(BaseModelManager):
                     logger.info(f"Starting download of LORA {lora['filename']}")
                     response = requests.get(lora["url"], timeout=self.REQUEST_DOWNLOAD_TIMEOUT)
                     response.raise_for_status()
+                    if "reason=download-auth" in response.url:
+                        logger.error(f"Error downloading {lora['filename']}. CivitAI appears to be redirecting us to a login page. Aborting")
+                        break
                     # Check the data hash
                     hash_object = hashlib.sha256()
                     hash_object.update(response.content)


### PR DESCRIPTION
Civitai is now allowing LoRa authors to only allow a LoRa to be downloaded by a logged in user. This change will prevent retrying to download it repeatedly when its doomed to fail in because of this.