### PR TITLE
fix: handle TI download failures more elegantly

### DIFF
--- a/hordelib/model_manager/ti.py
+++ b/hordelib/model_manager/ti.py
@@ -36,7 +36,7 @@ class TextualInversionModelManager(BaseModelManager):
     MAX_RETRIES: int = 10 if not TESTS_ONGOING else 3
     MAX_DOWNLOAD_THREADS: int = 3
     """The number of threads to use for downloading (the max number of concurrent downloads)."""
-    RETRY_DELAY: float = 5 if not TESTS_ONGOING else 0.2
+    RETRY_DELAY: float = 3 if not TESTS_ONGOING else 0.2
     """The time to wait between retries in seconds"""
     REQUEST_METADATA_TIMEOUT: int = 30
     """The time to wait for a metadata request to complete in seconds"""
@@ -281,9 +281,17 @@ class TextualInversionModelManager(BaseModelManager):
                         if hordeling_response.status_code == 404:
                             logger.debug(f"Textual Inversion: {ti['filename']} could not be found on AI Hordeling.")
                             break
+
+                        if hordeling_response.status_code == 500:
+                            retries += 2
+                            logger.debug(
+                                "AI Hordeing reported an internal error when downloading metadata. "
+                                "Fewer retries will be attempted.",
+                            )
+
                         # We will retry
                         logger.debug(
-                            "AI Horeling reported error when downloading metadata "
+                            "AI Hordeling reported error when downloading metadata "
                             f"for Textual Inversion: {ti['filename']}: "
                             f"{hordeling_response.json()}"
                             f"Retry {retries}/{self.MAX_RETRIES}",


### PR DESCRIPTION
- Presently, if [hordeling](https://github.com/Haidra-Org/AI-Hordeling) 500s, the worker can lose up to 45s per job while retrying at 5s intervals. 
  - If hordeling 500s, we're going to assume that something is critically wrong and try half the number of times.
  - I have changed the retry rate to be once every 3 seconds, while still remaining at up to 10, reducing the total possible time lost to 30s.
- As of https://github.com/Haidra-Org/hordelib/pull/112 and [recently implemented in reGen](https://github.com/Haidra-Org/horde-worker-reGen/issues/22), this will be reported back to the client, and so I see it as preferable to move forward with the generation as the client will be notified. Any image is better than no image, and it will prevent these sort of issues gumming up worker performance.