### PR TITLE
fix: lora orig name not searched in lowercase

### DIFF
--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -705,8 +705,8 @@ class LoraModelManager(BaseModelManager):
             return None
         if lora_name in self.model_reference:
             return lora_name
-        if lora_name in self._index_orig_names:
-            return self._index_orig_names[lora_name]
+        if lora_name.lower() in self._index_orig_names:
+            return self._index_orig_names[lora_name.lower()]
         if Sanitizer.has_unicode(lora_name):
             for lora in self._index_orig_names:
                 if lora_name in lora:

--- a/tests/model_managers/test_mm_lora.py
+++ b/tests/model_managers/test_mm_lora.py
@@ -103,6 +103,25 @@ class TestModelManagerLora:
         assert lora_model_manager.get_lora_filename("22591") == "GAG-RPGPotionsLoRaXL_197256.safetensors"
         lora_model_manager.stop_all()
 
+    def test_fetch_adhoc_lora_conflicting_fuzz(self):
+        lora_model_manager = LoraModelManager(
+            download_wait=False,
+            allowed_adhoc_lora_storage=1024,
+        )
+        lora_model_manager.download_default_loras()
+        lora_model_manager.wait_for_downloads(600)
+        lora_model_manager.wait_for_adhoc_reset(15)
+
+        lora_model_manager.fetch_adhoc_lora("33970")
+        lora_model_manager.ensure_lora_deleted("Eula Genshin Impact | Character Lora 1644")
+        lora_model_manager.fetch_adhoc_lora("Eula Genshin Impact | Character Lora 1644")
+        assert lora_model_manager.get_lora_name("33970") == "Dehya Genshin Impact | Character Lora 809".lower()
+        assert (
+            lora_model_manager.get_lora_name("Eula Genshin Impact | Character Lora 1644")
+            == "Eula Genshin Impact | Character Lora 1644".lower()
+        )
+        lora_model_manager.stop_all()
+
     def test_fetch_specific_lora_version(self):
         lora_model_manager = LoraModelManager(
             download_wait=False,


### PR DESCRIPTION
This fixes an issue where by not comparing lora names (given as the name of the model, as opposed to a version/model ID) using `.lower()` meant that not all LoRas were matching as was intended.