### PR TITLE
fix: try and fallback to on-disk model ref when can't download

### DIFF
--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -80,6 +80,21 @@ class SharedModelManager:
         download_legacy_references: bool = True,
         overwrite_existing_references: bool = True,
     ):
+        """Load the model managers specified.
+
+        Args:
+            managers_to_load (Iterable[str  |  MODEL_CATEGORY_NAMES  |  type[BaseModelManager]], optional): \
+                The model managers to load. \
+                Defaults to ALL_MODEL_MANAGER_TYPES.
+            multiprocessing_lock (multiprocessing_lock | None, optional): If you are using multiprocessing, \
+                you should pass a lock here. \
+                Defaults to None.
+            download_legacy_references (bool, optional): If True, this will download all legacy model references. \
+                Defaults to True.
+            overwrite_existing_references (bool, optional): If True, this will overwrite any existing legacy model \
+                references that might be already downloaded. \
+                Defaults to True.
+        """
         if cls.manager is None:
             cls.manager = ModelManager()
 

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -140,7 +140,7 @@ class SharedModelManager:
                 continue
 
             if parsed_reference not in _temp_reference_lookup:
-                logger.warning(f"Model reference doesn't require a legacy download: {reference}")
+                logger.debug(f"Model reference doesn't require a legacy download: {reference}")
                 continue
 
             references[parsed_reference] = get_model_reference_file_path(_temp_reference_lookup[parsed_reference])


### PR DESCRIPTION
Currently failures from github downloads will lead to the worker failing to start. This will allow hordelib to fail to on-disk references if they exist.