### PR TITLE
ci: use `CIVIT_API_TOKEN` in pr/main tests

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       HORDELIB_TESTING: "no-cuda"
       TESTS_ONGOING: "1"
+      CIVIT_API_TOKEN: ${{ secrets.CIVIT_API_TOKEN }}
     strategy:
       matrix:
         python: ["3.10"]

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       HORDELIB_TESTING: "no-cuda"
       TESTS_ONGOING: "1"
+      CIVIT_API_TOKEN: ${{ secrets.CIVIT_API_TOKEN }}
     strategy:
       matrix:
         python: ["3.10"]


### PR DESCRIPTION
Supports #162 