### PR TITLE
feat: update to comfy version `c5a369a`

### DIFF
--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -6,7 +6,7 @@ from strenum import StrEnum
 
 from hordelib.config_path import get_hordelib_path
 
-COMFYUI_VERSION = "b4e915e74560bd2c090f9b4ed6b73b0781b7050e"
+COMFYUI_VERSION = "c5a369a33ddb622827552716d9b0119035a2e666"
 """The exact version of ComfyUI version to load."""
 
 REMOTE_PROXY = ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,9 @@ from pathlib import Path
 import PIL.Image
 import pytest
 
+os.environ["TESTS_ONGOING"] = "1"
+
+
 from hordelib.comfy_horde import Comfy_Horde
 from hordelib.horde import HordeLib
 from hordelib.model_manager.hyper import ALL_MODEL_MANAGER_TYPES


### PR DESCRIPTION
See the diff for ComfyUI from the last update here: https://github.com/comfyanonymous/ComfyUI/compare/b4e915e74560bd2c090f9b4ed6b73b0781b7050e...c5a369a33ddb622827552716d9b0119035a2e666.

This would enable support for #176.