### PR TITLE
fix: remove `torchaudio` from deps 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pydantic
 torch>=2.1.0
 # xformers>=0.0.19
 torchvision
-torchaudio
+# torchaudio
 torchdiffeq
 torchsde
 einops


### PR DESCRIPTION
This is related to `Pyinstaller` failing in cryptic ways with it being included. It is not used by hordelib at this time, and its inclusion up to this point is largely in error.