### PR TITLE
fix: attempt to reload the json on fail

### DIFF
--- a/hordelib/utils/gpuinfo.py
+++ b/hordelib/utils/gpuinfo.py
@@ -160,7 +160,7 @@ class GPUInfoResult(BaseModel):
     product: str
     pci_gen: str
     pci_width: str
-    fan_speed: tuple[int, Unit]
+    fan_speed: tuple[str, Unit]
     vram_total: tuple[int, Unit]
     vram_used: tuple[int, Unit]
     vram_free: tuple[int, Unit]
@@ -186,7 +186,7 @@ class GPUInfoResult(BaseModel):
             product="unknown (stats with AMD not supported)",
             pci_gen="?",
             pci_width="?",
-            fan_speed=(0, Unit.percent),
+            fan_speed=("0", Unit.percent),
             vram_total=(0, Unit.megabytes),
             vram_used=(0, Unit.megabytes),
             vram_free=(0, Unit.megabytes),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,15 +138,17 @@ def pytest_collection_modifyitems(items):
         "tests.model_managers.test_shared_model_manager",
         "tests.test_mm_lora",
         "tests.test_mm_ti",
+        "tests.test_inference",
     ]
     MODULES_TO_RUN_LAST = [
-        "tests.test_inference",
         "tests.test_horde_inference",
         "tests.test_horde_inference_img2img",
+        "tests.test_horde_samplers",
+        "tests.test_horde_ti",
+        "tests.test_horde_lcm",
         "tests.test_horde_lora",
         "tests.test_horde_inference_controlnet",
         "tests.test_horde_inference_painting",
-        "tests.test_horde_samplers",
     ]
     module_mapping = {item: item.module.__name__ for item in items}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,8 @@ def shared_model_manager(hordelib_instance: HordeLib) -> Generator[type[SharedMo
     assert SharedModelManager.manager.validate_model("SDXL 1.0")
     assert SharedModelManager.manager.download_model("AlbedoBase XL (SDXL)")
     assert SharedModelManager.manager.validate_model("AlbedoBase XL (SDXL)")
+    assert SharedModelManager.manager.download_model("Rev Animated")
+    assert SharedModelManager.manager.validate_model("Rev Animated")
 
     assert SharedModelManager.manager.controlnet is not None
     assert SharedModelManager.manager.controlnet.download_all_models()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,8 @@ def shared_model_manager(hordelib_instance: HordeLib) -> Generator[type[SharedMo
     assert SharedModelManager.manager.validate_model("Deliberate")
     assert SharedModelManager.manager.download_model("SDXL 1.0")
     assert SharedModelManager.manager.validate_model("SDXL 1.0")
+    assert SharedModelManager.manager.download_model("AlbedoBase XL (SDXL)")
+    assert SharedModelManager.manager.validate_model("AlbedoBase XL (SDXL)")
 
     assert SharedModelManager.manager.controlnet is not None
     assert SharedModelManager.manager.controlnet.download_all_models()

--- a/tests/test_horde_samplers.py
+++ b/tests/test_horde_samplers.py
@@ -122,10 +122,15 @@ class TestHordeSamplers:
 
         for img_filename, pil_image in images_to_compare:
             logger.debug(f"Checking image {img_filename}")
-            assert check_single_inference_image_similarity(
-                img_filename,
-                pil_image,
-            )
+            if "sde" not in img_filename:
+                assert check_single_inference_image_similarity(
+                    img_filename,
+                    pil_image,
+                )
+            else:
+                logger.warning(
+                    f"Skipping image similarity check for {img_filename} due to SDE samplers being non-deterministic.",
+                )
 
     def test_slow_samplers(
         self,

--- a/tests/test_horde_samplers.py
+++ b/tests/test_horde_samplers.py
@@ -122,7 +122,7 @@ class TestHordeSamplers:
 
         for img_filename, pil_image in images_to_compare:
             logger.debug(f"Checking image {img_filename}")
-            if "sde" not in img_filename:
+            if "sde" not in img_filename and "lcm" not in img_filename:
                 assert check_single_inference_image_similarity(
                     img_filename,
                     pil_image,


### PR DESCRIPTION
- Some defensive programming surrounding the loading of the model references. This should help in the current multi-processing paradigm used in the worker until a more graceful solution can be put in place.
  - See #191 
- A minor fix to `GPUInfoResult` objects to support server environments (which return `"N/A"` for fan_speed as opposed to the typically expected `int` 0-100)
- Fixes the CI/tests to facilitate running on fresh/new dev machines. 