### PR TITLE
feat: Passes CivitAI token on checkpoint download as well (#202)

### DIFF
--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -599,6 +599,11 @@ class BaseModelManager(ABC):
 
             if "file_url" in download[i]:
                 download_url = download[i]["file_url"]
+                if self._civitai_api_token and self.is_model_url_from_civitai(download_url):
+                    if "?" not in download_url:
+                        download_url += f"?token={self._civitai_api_token}"
+                    else:
+                        download_url += f"&token={self._civitai_api_token}"
             if "file_name" in download[i]:
                 download_name = download[i]["file_name"]
             if "file_path" in download[i]:


### PR DESCRIPTION
Allows stable diffusion/`compvis` models to be downloaded by using a user-specified CivitAI API token.