### PR TITLE
feat: update to comfyui `a7dd82e`

### DIFF
--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -6,7 +6,7 @@ from strenum import StrEnum
 
 from hordelib.config_path import get_hordelib_path
 
-COMFYUI_VERSION = "a28a9dc83684624ee2167c0b92d976bb68f2c606"
+COMFYUI_VERSION = "a7dd82e668bfaf7fac365a4e73a1ba1acf224fbb"
 """The exact version of ComfyUI version to load."""
 
 REMOTE_PROXY = ""


### PR DESCRIPTION
See the diff for ComfyUI from the last update here: https://github.com/comfyanonymous/ComfyUI/compare/a28a9dc83684624ee2167c0b92d976bb68f2c606...a7dd82e668bfaf7fac365a4e73a1ba1acf224fbb

This includes several adjustments on comfyanonymous's part to memory management. This always represents a potential risk for the worker's second-layer memory management to break, but in limited testing, this hasn't been an issue as of yet. I will address new issues if they arise with subsequent patches to hordelib and/or reGen.

(See also #235)