### PR TITLE
ci/fix: don't use pypi api token for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,6 @@ jobs:
     - name: "📦 Publish distribution to PyPI"
       if: ${{ steps.release.outputs.version != '' }}
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
 
     # Update the badges (maybe, if we're lucky)
     - name: "📦 Refresh pypi badge cache"


### PR DESCRIPTION
see https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/