### PR TITLE
feat: Removes the requirement for a design pipeline

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
 
   build:
     runs-on: self-hosted

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --all-files
 
   build:
     runs-on: self-hosted

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -458,7 +458,7 @@ class Comfy_Horde:
 
         return data
 
-    def _fix_node_names(self, data: dict, design: dict) -> dict:
+    def _fix_node_names(self, data: dict) -> dict:
         """Rename nodes to the "title" set in the design file.
 
         Args:
@@ -472,15 +472,12 @@ class Comfy_Horde:
         # in the design file. These must be unique names.
         newnodes = {}
         renames = {}
-        nodes = design["nodes"]
-        for nodename, oldnode in data.items():
+        for nodename, nodedata in data.items():
             newname = nodename
-            for node in nodes:
-                if str(node["id"]) == str(nodename) and "title" in node:
-                    newname = node["title"]
-                    break
+            if nodedata.get("_meta", {}).get("title"):
+                newname = nodedata["_meta"]["title"]
             renames[nodename] = newname
-            newnodes[newname] = oldnode
+            newnodes[newname] = nodedata
 
         # Now we've renamed the node names, change any references to them also
         for node in newnodes.values():
@@ -504,13 +501,13 @@ class Comfy_Horde:
     #
     # Note also that the format of the design files from web app is expected to change at a fast
     # pace. This is why the only thing that partially relies on that format, is in fact, optional.
-    def _patch_pipeline(self, data: dict, design: dict) -> dict:
+    def _patch_pipeline(self, data: dict) -> dict:
         """Patch the pipeline data with the design data."""
         # FIXME: This can now be done through the _meta.title key included with each API export.
         # First replace comfyui standard types with hordelib node types
         data = self._fix_pipeline_types(data)
         # Now try to find better parameter names
-        return self._fix_node_names(data, design)
+        return self._fix_node_names(data)
 
     def _load_pipeline(self, filename: str) -> bool | None:
         """
@@ -540,17 +537,8 @@ class Comfy_Horde:
                 # Load the pipeline data from the file
                 pipeline_data = json.loads(jsonfile.read())
                 # Check if there is a design file for this pipeline
-                pipeline_design = os.path.join(
-                    os.path.dirname(os.path.dirname(filename)),
-                    "pipeline_designs",
-                    os.path.basename(filename),
-                )
-                # If there is a design file, patch the pipeline data with it
-                if os.path.exists(pipeline_design):
-                    logger.debug(f"Patching pipeline {pipeline_name}")
-                    with open(pipeline_design) as design_file:
-                        design_data = json.loads(design_file.read())
-                    pipeline_data = self._patch_pipeline(pipeline_data, design_data)
+                logger.debug(f"Patching pipeline {pipeline_name}")
+                pipeline_data = self._patch_pipeline(pipeline_data)
                 # Add the pipeline data to the pipelines dictionary
                 self.pipelines[pipeline_name] = pipeline_data
                 logger.debug(f"Loaded inference pipeline: {pipeline_name}")

--- a/hordelib/nodes/node_lora_loader.py
+++ b/hordelib/nodes/node_lora_loader.py
@@ -1,7 +1,7 @@
 import os
 
 import comfy.utils
-import folder_paths
+import folder_paths  # type: ignore
 from loguru import logger
 
 

--- a/hordelib/pipelines/pipeline_controlnet.json
+++ b/hordelib/pipelines/pipeline_controlnet.json
@@ -1,212 +1,269 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 123456789,
-            "steps": 25,
-            "cfg": 7.5,
-            "sampler_name": "dpmpp_2m",
-            "scheduler": "karras",
-            "denoise": 1.0,
-            "model": [
-                "47",
-                0
-            ],
-            "positive": [
-                "23",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "5",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 123456789,
+      "steps": 25,
+      "cfg": 7.5,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "karras",
+      "denoise": 1,
+      "model": [
+        "47",
+        0
+      ],
+      "positive": [
+        "23",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
     },
-    "5": {
-        "inputs": {
-            "width": 512,
-            "height": 512,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "7": {
-        "inputs": {
-            "text": "",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "49",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "20": {
-        "inputs": {
-            "image": "test_db0 (1).jpg",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "23": {
-        "inputs": {
-            "strength": 0.8500000000000003,
-            "conditioning": [
-                "24",
-                0
-            ],
-            "control_net": [
-                "33",
-                0
-            ],
-            "image": [
-                "34",
-                0
-            ]
-        },
-        "class_type": "ControlNetApply"
-    },
-    "24": {
-        "inputs": {
-            "text": "a man walking in the snow\n\n\n",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "33": {
-        "inputs": {
-            "control_net_name": "control_scribble_fp16.safetensors",
-            "model": [
-                "47",
-                0
-            ]
-        },
-        "class_type": "DiffControlNetLoader"
-    },
-    "34": {
-        "inputs": {
-            "low_threshold": 100,
-            "high_threshold": 200,
-            "l2gradient": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "CannyEdgePreprocessor"
-    },
-    "37": {
-        "inputs": {
-            "rm_nearest": 0,
-            "rm_background": 0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "LeReS-DepthMapPreprocessor"
-    },
-    "39": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "HEDPreprocessor"
-    },
-    "40": {
-        "inputs": {
-            "a": 6.283185307179586,
-            "bg_threshold": 0.05,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "MiDaS-NormalMapPreprocessor"
-    },
-    "42": {
-        "inputs": {
-            "detect_hand": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "OpenposePreprocessor"
-    },
-    "43": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "SemSegPreprocessor"
-    },
-    "44": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "ScribblePreprocessor"
-    },
-    "45": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "FakeScribblePreprocessor"
-    },
-    "46": {
-        "inputs": {
-            "score_threshold": 0.15,
-            "dist_threshold": 1,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "M-LSDPreprocessor"
-    },
-    "47": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "49": {
-        "inputs": {
-            "samples": [
-                "3",
-                0
-            ],
-            "vae": [
-                "47",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "49",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "20": {
+    "inputs": {
+      "image": "test_db0 (1).jpg",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "23": {
+    "inputs": {
+      "strength": 0.8500000000000003,
+      "conditioning": [
+        "24",
+        0
+      ],
+      "control_net": [
+        "33",
+        0
+      ],
+      "image": [
+        "34",
+        0
+      ]
+    },
+    "class_type": "ControlNetApply",
+    "_meta": {
+      "title": "controlnet_apply"
+    }
+  },
+  "24": {
+    "inputs": {
+      "text": "a man walking in the snow\n\n\n",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "33": {
+    "inputs": {
+      "control_net_name": "control_scribble_fp16.safetensors",
+      "model": [
+        "47",
+        0
+      ]
+    },
+    "class_type": "DiffControlNetLoader",
+    "_meta": {
+      "title": "controlnet_model_loader"
+    }
+  },
+  "34": {
+    "inputs": {
+      "low_threshold": 100,
+      "high_threshold": 200,
+      "l2gradient": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "CannyEdgePreprocessor",
+    "_meta": {
+      "title": "canny"
+    }
+  },
+  "37": {
+    "inputs": {
+      "rm_nearest": 0,
+      "rm_background": 0,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "LeReS-DepthMapPreprocessor",
+    "_meta": {
+      "title": "depth"
+    }
+  },
+  "39": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "HEDPreprocessor",
+    "_meta": {
+      "title": "hed"
+    }
+  },
+  "40": {
+    "inputs": {
+      "a": 6.283185307179586,
+      "bg_threshold": 0.05,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "MiDaS-NormalMapPreprocessor",
+    "_meta": {
+      "title": "normal"
+    }
+  },
+  "42": {
+    "inputs": {
+      "detect_hand": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "OpenposePreprocessor",
+    "_meta": {
+      "title": "openpose"
+    }
+  },
+  "43": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "SemSegPreprocessor",
+    "_meta": {
+      "title": "seg"
+    }
+  },
+  "44": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "ScribblePreprocessor",
+    "_meta": {
+      "title": "scribble"
+    }
+  },
+  "45": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "FakeScribblePreprocessor",
+    "_meta": {
+      "title": "fakescribble"
+    }
+  },
+  "46": {
+    "inputs": {
+      "score_threshold": 0.15,
+      "dist_threshold": 1,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "M-LSDPreprocessor",
+    "_meta": {
+      "title": "mlsd"
+    }
+  },
+  "47": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "49": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "47",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "vae_decode"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_controlnet.json
+++ b/hordelib/pipelines/pipeline_controlnet.json
@@ -1,212 +1,282 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 123456789,
-            "steps": 25,
-            "cfg": 7.5,
-            "sampler_name": "dpmpp_2m",
-            "scheduler": "karras",
-            "denoise": 1.0,
-            "model": [
-                "47",
-                0
-            ],
-            "positive": [
-                "23",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "5",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 123456789,
+      "steps": 25,
+      "cfg": 7.5,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "karras",
+      "denoise": 1,
+      "model": [
+        "47",
+        0
+      ],
+      "positive": [
+        "23",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
     },
-    "5": {
-        "inputs": {
-            "width": 512,
-            "height": 512,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "7": {
-        "inputs": {
-            "text": "",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "49",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "20": {
-        "inputs": {
-            "image": "test_db0 (1).jpg",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "23": {
-        "inputs": {
-            "strength": 0.8500000000000003,
-            "conditioning": [
-                "24",
-                0
-            ],
-            "control_net": [
-                "33",
-                0
-            ],
-            "image": [
-                "34",
-                0
-            ]
-        },
-        "class_type": "ControlNetApply"
-    },
-    "24": {
-        "inputs": {
-            "text": "a man walking in the snow\n\n\n",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "33": {
-        "inputs": {
-            "control_net_name": "control_scribble_fp16.safetensors",
-            "model": [
-                "47",
-                0
-            ]
-        },
-        "class_type": "DiffControlNetLoader"
-    },
-    "34": {
-        "inputs": {
-            "low_threshold": 100,
-            "high_threshold": 200,
-            "l2gradient": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "CannyEdgePreprocessor"
-    },
-    "37": {
-        "inputs": {
-            "rm_nearest": 0,
-            "rm_background": 0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "LeReS-DepthMapPreprocessor"
-    },
-    "39": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "HEDPreprocessor"
-    },
-    "40": {
-        "inputs": {
-            "a": 6.283185307179586,
-            "bg_threshold": 0.05,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "MiDaS-NormalMapPreprocessor"
-    },
-    "42": {
-        "inputs": {
-            "detect_hand": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "OpenposePreprocessor"
-    },
-    "43": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "SemSegPreprocessor"
-    },
-    "44": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "ScribblePreprocessor"
-    },
-    "45": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "FakeScribblePreprocessor"
-    },
-    "46": {
-        "inputs": {
-            "score_threshold": 0.15,
-            "dist_threshold": 1,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "M-LSDPreprocessor"
-    },
-    "47": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "49": {
-        "inputs": {
-            "samples": [
-                "3",
-                0
-            ],
-            "vae": [
-                "47",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "49",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "20": {
+    "inputs": {
+      "image": "test_db0 (1).jpg",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "23": {
+    "inputs": {
+      "strength": 0.8500000000000003,
+      "conditioning": [
+        "24",
+        0
+      ],
+      "control_net": [
+        "33",
+        0
+      ],
+      "image": [
+        "34",
+        0
+      ]
+    },
+    "class_type": "ControlNetApply",
+    "_meta": {
+      "title": "controlnet_apply"
+    }
+  },
+  "24": {
+    "inputs": {
+      "text": "a man walking in the snow\n\n\n",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "33": {
+    "inputs": {
+      "control_net_name": "control_scribble_fp16.safetensors",
+      "model": [
+        "47",
+        0
+      ]
+    },
+    "class_type": "DiffControlNetLoader",
+    "_meta": {
+      "title": "controlnet_model_loader"
+    }
+  },
+  "34": {
+    "inputs": {
+      "low_threshold": 100,
+      "high_threshold": 200,
+      "resolution": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "CannyEdgePreprocessor",
+    "_meta": {
+      "title": "canny"
+    }
+  },
+  "37": {
+    "inputs": {
+      "rm_nearest": 0,
+      "rm_background": 0,
+      "boost": "disable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "LeReS-DepthMapPreprocessor",
+    "_meta": {
+      "title": "depth"
+    }
+  },
+  "39": {
+    "inputs": {
+      "safe": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "HEDPreprocessor",
+    "_meta": {
+      "title": "hed"
+    }
+  },
+  "40": {
+    "inputs": {
+      "a": 6.283185307179586,
+      "bg_threshold": 0.05,
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "MiDaS-NormalMapPreprocessor",
+    "_meta": {
+      "title": "normal"
+    }
+  },
+  "42": {
+    "inputs": {
+      "detect_hand": "disable",
+      "detect_body": "enable",
+      "detect_face": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "OpenposePreprocessor",
+    "_meta": {
+      "title": "openpose"
+    }
+  },
+  "43": {
+    "inputs": {
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "SemSegPreprocessor",
+    "_meta": {
+      "title": "seg"
+    }
+  },
+  "44": {
+    "inputs": {
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "ScribblePreprocessor",
+    "_meta": {
+      "title": "scribble"
+    }
+  },
+  "45": {
+    "inputs": {
+      "safe": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "FakeScribblePreprocessor",
+    "_meta": {
+      "title": "fakescribble"
+    }
+  },
+  "46": {
+    "inputs": {
+      "score_threshold": 0.15,
+      "dist_threshold": 1,
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "M-LSDPreprocessor",
+    "_meta": {
+      "title": "mlsd"
+    }
+  },
+  "47": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "49": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "47",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "vae_decode"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_controlnet.json
+++ b/hordelib/pipelines/pipeline_controlnet.json
@@ -1,282 +1,212 @@
 {
-  "3": {
-    "inputs": {
-      "seed": 123456789,
-      "steps": 25,
-      "cfg": 7.5,
-      "sampler_name": "dpmpp_2m",
-      "scheduler": "karras",
-      "denoise": 1,
-      "model": [
-        "47",
-        0
-      ],
-      "positive": [
-        "23",
-        0
-      ],
-      "negative": [
-        "7",
-        0
-      ],
-      "latent_image": [
-        "5",
-        0
-      ]
+    "3": {
+        "inputs": {
+            "seed": 123456789,
+            "steps": 25,
+            "cfg": 7.5,
+            "sampler_name": "dpmpp_2m",
+            "scheduler": "karras",
+            "denoise": 1.0,
+            "model": [
+                "47",
+                0
+            ],
+            "positive": [
+                "23",
+                0
+            ],
+            "negative": [
+                "7",
+                0
+            ],
+            "latent_image": [
+                "5",
+                0
+            ]
+        },
+        "class_type": "KSampler"
     },
-    "class_type": "KSampler",
-    "_meta": {
-      "title": "sampler"
-    }
-  },
-  "5": {
-    "inputs": {
-      "width": 512,
-      "height": 512,
-      "batch_size": 1
+    "5": {
+        "inputs": {
+            "width": 512,
+            "height": 512,
+            "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage"
     },
-    "class_type": "EmptyLatentImage",
-    "_meta": {
-      "title": "empty_latent_image"
-    }
-  },
-  "7": {
-    "inputs": {
-      "text": "",
-      "clip": [
-        "47",
-        1
-      ]
+    "7": {
+        "inputs": {
+            "text": "",
+            "clip": [
+                "47",
+                1
+            ]
+        },
+        "class_type": "CLIPTextEncode"
     },
-    "class_type": "CLIPTextEncode",
-    "_meta": {
-      "title": "negative_prompt"
-    }
-  },
-  "9": {
-    "inputs": {
-      "filename_prefix": "ComfyUI",
-      "images": [
-        "49",
-        0
-      ]
+    "9": {
+        "inputs": {
+            "filename_prefix": "ComfyUI",
+            "images": [
+                "49",
+                0
+            ]
+        },
+        "class_type": "SaveImage"
     },
-    "class_type": "SaveImage",
-    "_meta": {
-      "title": "output_image"
-    }
-  },
-  "20": {
-    "inputs": {
-      "image": "test_db0 (1).jpg",
-      "upload": "image"
+    "20": {
+        "inputs": {
+            "image": "test_db0 (1).jpg",
+            "choose file to upload": "image"
+        },
+        "class_type": "LoadImage"
     },
-    "class_type": "LoadImage",
-    "_meta": {
-      "title": "image_loader"
-    }
-  },
-  "23": {
-    "inputs": {
-      "strength": 0.8500000000000003,
-      "conditioning": [
-        "24",
-        0
-      ],
-      "control_net": [
-        "33",
-        0
-      ],
-      "image": [
-        "34",
-        0
-      ]
+    "23": {
+        "inputs": {
+            "strength": 0.8500000000000003,
+            "conditioning": [
+                "24",
+                0
+            ],
+            "control_net": [
+                "33",
+                0
+            ],
+            "image": [
+                "34",
+                0
+            ]
+        },
+        "class_type": "ControlNetApply"
     },
-    "class_type": "ControlNetApply",
-    "_meta": {
-      "title": "controlnet_apply"
-    }
-  },
-  "24": {
-    "inputs": {
-      "text": "a man walking in the snow\n\n\n",
-      "clip": [
-        "47",
-        1
-      ]
+    "24": {
+        "inputs": {
+            "text": "a man walking in the snow\n\n\n",
+            "clip": [
+                "47",
+                1
+            ]
+        },
+        "class_type": "CLIPTextEncode"
     },
-    "class_type": "CLIPTextEncode",
-    "_meta": {
-      "title": "prompt"
-    }
-  },
-  "33": {
-    "inputs": {
-      "control_net_name": "control_scribble_fp16.safetensors",
-      "model": [
-        "47",
-        0
-      ]
+    "33": {
+        "inputs": {
+            "control_net_name": "control_scribble_fp16.safetensors",
+            "model": [
+                "47",
+                0
+            ]
+        },
+        "class_type": "DiffControlNetLoader"
     },
-    "class_type": "DiffControlNetLoader",
-    "_meta": {
-      "title": "controlnet_model_loader"
-    }
-  },
-  "34": {
-    "inputs": {
-      "low_threshold": 100,
-      "high_threshold": 200,
-      "resolution": "disable",
-      "image": [
-        "20",
-        0
-      ]
+    "34": {
+        "inputs": {
+            "low_threshold": 100,
+            "high_threshold": 200,
+            "l2gradient": "disable",
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "CannyEdgePreprocessor"
     },
-    "class_type": "CannyEdgePreprocessor",
-    "_meta": {
-      "title": "canny"
-    }
-  },
-  "37": {
-    "inputs": {
-      "rm_nearest": 0,
-      "rm_background": 0,
-      "boost": "disable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "37": {
+        "inputs": {
+            "rm_nearest": 0,
+            "rm_background": 0,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "LeReS-DepthMapPreprocessor"
     },
-    "class_type": "LeReS-DepthMapPreprocessor",
-    "_meta": {
-      "title": "depth"
-    }
-  },
-  "39": {
-    "inputs": {
-      "safe": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "39": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "HEDPreprocessor"
     },
-    "class_type": "HEDPreprocessor",
-    "_meta": {
-      "title": "hed"
-    }
-  },
-  "40": {
-    "inputs": {
-      "a": 6.283185307179586,
-      "bg_threshold": 0.05,
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "40": {
+        "inputs": {
+            "a": 6.283185307179586,
+            "bg_threshold": 0.05,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "MiDaS-NormalMapPreprocessor"
     },
-    "class_type": "MiDaS-NormalMapPreprocessor",
-    "_meta": {
-      "title": "normal"
-    }
-  },
-  "42": {
-    "inputs": {
-      "detect_hand": "disable",
-      "detect_body": "enable",
-      "detect_face": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "42": {
+        "inputs": {
+            "detect_hand": "disable",
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "OpenposePreprocessor"
     },
-    "class_type": "OpenposePreprocessor",
-    "_meta": {
-      "title": "openpose"
-    }
-  },
-  "43": {
-    "inputs": {
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "43": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "SemSegPreprocessor"
     },
-    "class_type": "SemSegPreprocessor",
-    "_meta": {
-      "title": "seg"
-    }
-  },
-  "44": {
-    "inputs": {
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "44": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "ScribblePreprocessor"
     },
-    "class_type": "ScribblePreprocessor",
-    "_meta": {
-      "title": "scribble"
-    }
-  },
-  "45": {
-    "inputs": {
-      "safe": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "45": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "FakeScribblePreprocessor"
     },
-    "class_type": "FakeScribblePreprocessor",
-    "_meta": {
-      "title": "fakescribble"
-    }
-  },
-  "46": {
-    "inputs": {
-      "score_threshold": 0.15,
-      "dist_threshold": 1,
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "46": {
+        "inputs": {
+            "score_threshold": 0.15,
+            "dist_threshold": 1,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "M-LSDPreprocessor"
     },
-    "class_type": "M-LSDPreprocessor",
-    "_meta": {
-      "title": "mlsd"
-    }
-  },
-  "47": {
-    "inputs": {
-      "ckpt_name": "Deliberate.ckpt"
+    "47": {
+        "inputs": {
+            "ckpt_name": "Deliberate.ckpt"
+        },
+        "class_type": "CheckpointLoaderSimple"
     },
-    "class_type": "CheckpointLoaderSimple",
-    "_meta": {
-      "title": "model_loader"
+    "49": {
+        "inputs": {
+            "samples": [
+                "3",
+                0
+            ],
+            "vae": [
+                "47",
+                2
+            ]
+        },
+        "class_type": "VAEDecode"
     }
-  },
-  "49": {
-    "inputs": {
-      "samples": [
-        "3",
-        0
-      ],
-      "vae": [
-        "47",
-        2
-      ]
-    },
-    "class_type": "VAEDecode",
-    "_meta": {
-      "title": "vae_decode"
-    }
-  }
 }

--- a/hordelib/pipelines/pipeline_controlnet_annotator.json
+++ b/hordelib/pipelines/pipeline_controlnet_annotator.json
@@ -1,110 +1,144 @@
 {
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "45",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "45",
+        0
+      ]
     },
-    "20": {
-        "inputs": {
-            "image": "horde_image_facefix_codeformers.webp",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "34": {
-        "inputs": {
-            "low_threshold": 100,
-            "high_threshold": 200,
-            "l2gradient": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "CannyEdgePreprocessor"
-    },
-    "37": {
-        "inputs": {
-            "rm_nearest": 0,
-            "rm_background": 0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "LeReS-DepthMapPreprocessor"
-    },
-    "39": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "HEDPreprocessor"
-    },
-    "40": {
-        "inputs": {
-            "a": 6.283185307179586,
-            "bg_threshold": 0.05,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "MiDaS-NormalMapPreprocessor"
-    },
-    "42": {
-        "inputs": {
-            "detect_hand": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "OpenposePreprocessor"
-    },
-    "43": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "SemSegPreprocessor"
-    },
-    "44": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "ScribblePreprocessor"
-    },
-    "45": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "FakeScribblePreprocessor"
-    },
-    "46": {
-        "inputs": {
-            "score_threshold": 0.150,
-            "dist_threshold": 1.0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "M-LSDPreprocessor"
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
     }
+  },
+  "20": {
+    "inputs": {
+      "image": "horde_image_facefix_codeformers.webp",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "34": {
+    "inputs": {
+      "low_threshold": 100,
+      "high_threshold": 200,
+      "l2gradient": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "CannyEdgePreprocessor",
+    "_meta": {
+      "title": "canny"
+    }
+  },
+  "37": {
+    "inputs": {
+      "rm_nearest": 0,
+      "rm_background": 0,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "LeReS-DepthMapPreprocessor",
+    "_meta": {
+      "title": "depth"
+    }
+  },
+  "39": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "HEDPreprocessor",
+    "_meta": {
+      "title": "hed"
+    }
+  },
+  "40": {
+    "inputs": {
+      "a": 6.283185307179586,
+      "bg_threshold": 0.05,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "MiDaS-NormalMapPreprocessor",
+    "_meta": {
+      "title": "normal"
+    }
+  },
+  "42": {
+    "inputs": {
+      "detect_hand": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "OpenposePreprocessor",
+    "_meta": {
+      "title": "openpose"
+    }
+  },
+  "43": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "SemSegPreprocessor",
+    "_meta": {
+      "title": "seg"
+    }
+  },
+  "44": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "ScribblePreprocessor",
+    "_meta": {
+      "title": "scribble"
+    }
+  },
+  "45": {
+    "inputs": {
+      "safe": "enable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "FakeScribblePreprocessor",
+    "_meta": {
+      "title": "fakescribble"
+    }
+  },
+  "46": {
+    "inputs": {
+      "score_threshold": 0.15,
+      "dist_threshold": 1,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "M-LSDPreprocessor",
+    "_meta": {
+      "title": "mlsd"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_controlnet_annotator.json
+++ b/hordelib/pipelines/pipeline_controlnet_annotator.json
@@ -1,156 +1,110 @@
 {
-  "9": {
-    "inputs": {
-      "filename_prefix": "ComfyUI",
-      "images": [
-        "45",
-        0
-      ]
+    "9": {
+        "inputs": {
+            "filename_prefix": "ComfyUI",
+            "images": [
+                "45",
+                0
+            ]
+        },
+        "class_type": "SaveImage"
     },
-    "class_type": "SaveImage",
-    "_meta": {
-      "title": "output_image"
-    }
-  },
-  "20": {
-    "inputs": {
-      "image": "horde_image_facefix_codeformers.webp",
-      "upload": "image"
+    "20": {
+        "inputs": {
+            "image": "horde_image_facefix_codeformers.webp",
+            "choose file to upload": "image"
+        },
+        "class_type": "LoadImage"
     },
-    "class_type": "LoadImage",
-    "_meta": {
-      "title": "image_loader"
-    }
-  },
-  "34": {
-    "inputs": {
-      "low_threshold": 100,
-      "high_threshold": 200,
-      "resolution": "disable",
-      "image": [
-        "20",
-        0
-      ]
+    "34": {
+        "inputs": {
+            "low_threshold": 100,
+            "high_threshold": 200,
+            "l2gradient": "disable",
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "CannyEdgePreprocessor"
     },
-    "class_type": "CannyEdgePreprocessor",
-    "_meta": {
-      "title": "canny"
-    }
-  },
-  "37": {
-    "inputs": {
-      "rm_nearest": 0,
-      "rm_background": 0,
-      "boost": "disable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "37": {
+        "inputs": {
+            "rm_nearest": 0,
+            "rm_background": 0,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "LeReS-DepthMapPreprocessor"
     },
-    "class_type": "LeReS-DepthMapPreprocessor",
-    "_meta": {
-      "title": "depth"
-    }
-  },
-  "39": {
-    "inputs": {
-      "safe": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "39": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "HEDPreprocessor"
     },
-    "class_type": "HEDPreprocessor",
-    "_meta": {
-      "title": "hed"
-    }
-  },
-  "40": {
-    "inputs": {
-      "a": 6.283185307179586,
-      "bg_threshold": 0.05,
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "40": {
+        "inputs": {
+            "a": 6.283185307179586,
+            "bg_threshold": 0.05,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "MiDaS-NormalMapPreprocessor"
     },
-    "class_type": "MiDaS-NormalMapPreprocessor",
-    "_meta": {
-      "title": "normal"
-    }
-  },
-  "42": {
-    "inputs": {
-      "detect_hand": "disable",
-      "detect_body": "enable",
-      "detect_face": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "42": {
+        "inputs": {
+            "detect_hand": "disable",
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "OpenposePreprocessor"
     },
-    "class_type": "OpenposePreprocessor",
-    "_meta": {
-      "title": "openpose"
-    }
-  },
-  "43": {
-    "inputs": {
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "43": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "SemSegPreprocessor"
     },
-    "class_type": "SemSegPreprocessor",
-    "_meta": {
-      "title": "seg"
-    }
-  },
-  "44": {
-    "inputs": {
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "44": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "ScribblePreprocessor"
     },
-    "class_type": "ScribblePreprocessor",
-    "_meta": {
-      "title": "scribble"
-    }
-  },
-  "45": {
-    "inputs": {
-      "safe": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "45": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "FakeScribblePreprocessor"
     },
-    "class_type": "FakeScribblePreprocessor",
-    "_meta": {
-      "title": "fakescribble"
+    "46": {
+        "inputs": {
+            "score_threshold": 0.150,
+            "dist_threshold": 1.0,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "M-LSDPreprocessor"
     }
-  },
-  "46": {
-    "inputs": {
-      "score_threshold": 0.15,
-      "dist_threshold": 1,
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
-    },
-    "class_type": "M-LSDPreprocessor",
-    "_meta": {
-      "title": "mlsd"
-    }
-  }
 }

--- a/hordelib/pipelines/pipeline_controlnet_annotator.json
+++ b/hordelib/pipelines/pipeline_controlnet_annotator.json
@@ -1,110 +1,156 @@
 {
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "45",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "45",
+        0
+      ]
     },
-    "20": {
-        "inputs": {
-            "image": "horde_image_facefix_codeformers.webp",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "34": {
-        "inputs": {
-            "low_threshold": 100,
-            "high_threshold": 200,
-            "l2gradient": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "CannyEdgePreprocessor"
-    },
-    "37": {
-        "inputs": {
-            "rm_nearest": 0,
-            "rm_background": 0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "LeReS-DepthMapPreprocessor"
-    },
-    "39": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "HEDPreprocessor"
-    },
-    "40": {
-        "inputs": {
-            "a": 6.283185307179586,
-            "bg_threshold": 0.05,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "MiDaS-NormalMapPreprocessor"
-    },
-    "42": {
-        "inputs": {
-            "detect_hand": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "OpenposePreprocessor"
-    },
-    "43": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "SemSegPreprocessor"
-    },
-    "44": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "ScribblePreprocessor"
-    },
-    "45": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "FakeScribblePreprocessor"
-    },
-    "46": {
-        "inputs": {
-            "score_threshold": 0.150,
-            "dist_threshold": 1.0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "M-LSDPreprocessor"
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
     }
+  },
+  "20": {
+    "inputs": {
+      "image": "horde_image_facefix_codeformers.webp",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "34": {
+    "inputs": {
+      "low_threshold": 100,
+      "high_threshold": 200,
+      "resolution": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "CannyEdgePreprocessor",
+    "_meta": {
+      "title": "canny"
+    }
+  },
+  "37": {
+    "inputs": {
+      "rm_nearest": 0,
+      "rm_background": 0,
+      "boost": "disable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "LeReS-DepthMapPreprocessor",
+    "_meta": {
+      "title": "depth"
+    }
+  },
+  "39": {
+    "inputs": {
+      "safe": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "HEDPreprocessor",
+    "_meta": {
+      "title": "hed"
+    }
+  },
+  "40": {
+    "inputs": {
+      "a": 6.283185307179586,
+      "bg_threshold": 0.05,
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "MiDaS-NormalMapPreprocessor",
+    "_meta": {
+      "title": "normal"
+    }
+  },
+  "42": {
+    "inputs": {
+      "detect_hand": "disable",
+      "detect_body": "enable",
+      "detect_face": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "OpenposePreprocessor",
+    "_meta": {
+      "title": "openpose"
+    }
+  },
+  "43": {
+    "inputs": {
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "SemSegPreprocessor",
+    "_meta": {
+      "title": "seg"
+    }
+  },
+  "44": {
+    "inputs": {
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "ScribblePreprocessor",
+    "_meta": {
+      "title": "scribble"
+    }
+  },
+  "45": {
+    "inputs": {
+      "safe": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "FakeScribblePreprocessor",
+    "_meta": {
+      "title": "fakescribble"
+    }
+  },
+  "46": {
+    "inputs": {
+      "score_threshold": 0.15,
+      "dist_threshold": 1,
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "M-LSDPreprocessor",
+    "_meta": {
+      "title": "mlsd"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_controlnet_hires_fix.json
+++ b/hordelib/pipelines/pipeline_controlnet_hires_fix.json
@@ -1,252 +1,315 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 123456789,
-            "steps": 25,
-            "cfg": 7.5,
-            "sampler_name": "dpmpp_2m",
-            "scheduler": "karras",
-            "denoise": 1.0,
-            "model": [
-                "47",
-                0
-            ],
-            "positive": [
-                "23",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "5",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 123456789,
+      "steps": 25,
+      "cfg": 7.5,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "karras",
+      "denoise": 1,
+      "model": [
+        "47",
+        0
+      ],
+      "positive": [
+        "23",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
     },
-    "5": {
-        "inputs": {
-            "width": 512,
-            "height": 512,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "7": {
-        "inputs": {
-            "text": "",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "52",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "20": {
-        "inputs": {
-            "image": "test_db0 (2).jpg",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "23": {
-        "inputs": {
-            "strength": 0.8500000000000003,
-            "conditioning": [
-                "24",
-                0
-            ],
-            "control_net": [
-                "33",
-                0
-            ],
-            "image": [
-                "34",
-                0
-            ]
-        },
-        "class_type": "ControlNetApply"
-    },
-    "24": {
-        "inputs": {
-            "text": "a man walking in the jungle\n\n\n",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "33": {
-        "inputs": {
-            "control_net_name": "control_scribble_fp16.safetensors",
-            "model": [
-                "47",
-                0
-            ]
-        },
-        "class_type": "DiffControlNetLoader"
-    },
-    "34": {
-        "inputs": {
-            "low_threshold": 100,
-            "high_threshold": 200,
-            "l2gradient": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "CannyEdgePreprocessor"
-    },
-    "37": {
-        "inputs": {
-            "rm_nearest": 0,
-            "rm_background": 0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "LeReS-DepthMapPreprocessor"
-    },
-    "39": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "HEDPreprocessor"
-    },
-    "40": {
-        "inputs": {
-            "a": 6.283185307179586,
-            "bg_threshold": 0.05,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "MiDaS-NormalMapPreprocessor"
-    },
-    "42": {
-        "inputs": {
-            "detect_hand": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "OpenposePreprocessor"
-    },
-    "43": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "SemSegPreprocessor"
-    },
-    "44": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "ScribblePreprocessor"
-    },
-    "45": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "FakeScribblePreprocessor"
-    },
-    "46": {
-        "inputs": {
-            "score_threshold": 0.15,
-            "dist_threshold": 1,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "M-LSDPreprocessor"
-    },
-    "47": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "49": {
-        "inputs": {
-            "upscale_method": "nearest-exact",
-            "width": 768,
-            "height": 768,
-            "crop": "disabled",
-            "samples": [
-                "3",
-                0
-            ]
-        },
-        "class_type": "LatentUpscale"
-    },
-    "50": {
-        "inputs": {
-            "seed": 287046928977701,
-            "steps": 15,
-            "cfg": 8.0,
-            "sampler_name": "dpmpp_2m",
-            "scheduler": "simple",
-            "denoise": 0.6,
-            "model": [
-                "47",
-                0
-            ],
-            "positive": [
-                "24",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "49",
-                0
-            ]
-        },
-        "class_type": "KSampler"
-    },
-    "52": {
-        "inputs": {
-            "samples": [
-                "50",
-                0
-            ],
-            "vae": [
-                "47",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "52",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "20": {
+    "inputs": {
+      "image": "example.png",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "23": {
+    "inputs": {
+      "strength": 0.8500000000000003,
+      "conditioning": [
+        "24",
+        0
+      ],
+      "control_net": [
+        "33",
+        0
+      ],
+      "image": [
+        "34",
+        0
+      ]
+    },
+    "class_type": "ControlNetApply",
+    "_meta": {
+      "title": "controlnet_apply"
+    }
+  },
+  "24": {
+    "inputs": {
+      "text": "a man walking in the jungle\n\n\n",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "33": {
+    "inputs": {
+      "control_net_name": "control_scribble_fp16.safetensors",
+      "model": [
+        "47",
+        0
+      ]
+    },
+    "class_type": "DiffControlNetLoader",
+    "_meta": {
+      "title": "controlnet_model_loader"
+    }
+  },
+  "34": {
+    "inputs": {
+      "low_threshold": 100,
+      "high_threshold": 200,
+      "l2gradient": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "CannyEdgePreprocessor",
+    "_meta": {
+      "title": "canny"
+    }
+  },
+  "37": {
+    "inputs": {
+      "rm_nearest": 0,
+      "rm_background": 0,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "LeReS-DepthMapPreprocessor",
+    "_meta": {
+      "title": "depth"
+    }
+  },
+  "39": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "HEDPreprocessor",
+    "_meta": {
+      "title": "hed"
+    }
+  },
+  "40": {
+    "inputs": {
+      "a": 6.283185307179586,
+      "bg_threshold": 0.05,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "MiDaS-NormalMapPreprocessor",
+    "_meta": {
+      "title": "normal"
+    }
+  },
+  "42": {
+    "inputs": {
+      "detect_hand": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "OpenposePreprocessor",
+    "_meta": {
+      "title": "openpose"
+    }
+  },
+  "43": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "SemSegPreprocessor",
+    "_meta": {
+      "title": "seg"
+    }
+  },
+  "44": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "ScribblePreprocessor",
+    "_meta": {
+      "title": "scribble"
+    }
+  },
+  "45": {
+    "inputs": {
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "FakeScribblePreprocessor",
+    "_meta": {
+      "title": "fakescribble"
+    }
+  },
+  "46": {
+    "inputs": {
+      "score_threshold": 0.15,
+      "dist_threshold": 1,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "M-LSDPreprocessor",
+    "_meta": {
+      "title": "mlsd"
+    }
+  },
+  "47": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "49": {
+    "inputs": {
+      "upscale_method": "nearest-exact",
+      "width": 768,
+      "height": 768,
+      "crop": "disabled",
+      "samples": [
+        "3",
+        0
+      ]
+    },
+    "class_type": "LatentUpscale",
+    "_meta": {
+      "title": "latent_upscale"
+    }
+  },
+  "50": {
+    "inputs": {
+      "seed": 287046928977701,
+      "steps": 15,
+      "cfg": 8,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "simple",
+      "denoise": 0.6,
+      "model": [
+        "47",
+        0
+      ],
+      "positive": [
+        "24",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "49",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "upscale_sampler"
+    }
+  },
+  "52": {
+    "inputs": {
+      "samples": [
+        "50",
+        0
+      ],
+      "vae": [
+        "47",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "vae_decode"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_controlnet_hires_fix.json
+++ b/hordelib/pipelines/pipeline_controlnet_hires_fix.json
@@ -1,252 +1,328 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 123456789,
-            "steps": 25,
-            "cfg": 7.5,
-            "sampler_name": "dpmpp_2m",
-            "scheduler": "karras",
-            "denoise": 1.0,
-            "model": [
-                "47",
-                0
-            ],
-            "positive": [
-                "23",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "5",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 123456789,
+      "steps": 25,
+      "cfg": 7.5,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "karras",
+      "denoise": 1,
+      "model": [
+        "47",
+        0
+      ],
+      "positive": [
+        "23",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
     },
-    "5": {
-        "inputs": {
-            "width": 512,
-            "height": 512,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "7": {
-        "inputs": {
-            "text": "",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "52",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "20": {
-        "inputs": {
-            "image": "test_db0 (2).jpg",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "23": {
-        "inputs": {
-            "strength": 0.8500000000000003,
-            "conditioning": [
-                "24",
-                0
-            ],
-            "control_net": [
-                "33",
-                0
-            ],
-            "image": [
-                "34",
-                0
-            ]
-        },
-        "class_type": "ControlNetApply"
-    },
-    "24": {
-        "inputs": {
-            "text": "a man walking in the jungle\n\n\n",
-            "clip": [
-                "47",
-                1
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "33": {
-        "inputs": {
-            "control_net_name": "control_scribble_fp16.safetensors",
-            "model": [
-                "47",
-                0
-            ]
-        },
-        "class_type": "DiffControlNetLoader"
-    },
-    "34": {
-        "inputs": {
-            "low_threshold": 100,
-            "high_threshold": 200,
-            "l2gradient": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "CannyEdgePreprocessor"
-    },
-    "37": {
-        "inputs": {
-            "rm_nearest": 0,
-            "rm_background": 0,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "LeReS-DepthMapPreprocessor"
-    },
-    "39": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "HEDPreprocessor"
-    },
-    "40": {
-        "inputs": {
-            "a": 6.283185307179586,
-            "bg_threshold": 0.05,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "MiDaS-NormalMapPreprocessor"
-    },
-    "42": {
-        "inputs": {
-            "detect_hand": "disable",
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "OpenposePreprocessor"
-    },
-    "43": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "SemSegPreprocessor"
-    },
-    "44": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "ScribblePreprocessor"
-    },
-    "45": {
-        "inputs": {
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "FakeScribblePreprocessor"
-    },
-    "46": {
-        "inputs": {
-            "score_threshold": 0.15,
-            "dist_threshold": 1,
-            "image": [
-                "20",
-                0
-            ]
-        },
-        "class_type": "M-LSDPreprocessor"
-    },
-    "47": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "49": {
-        "inputs": {
-            "upscale_method": "nearest-exact",
-            "width": 768,
-            "height": 768,
-            "crop": "disabled",
-            "samples": [
-                "3",
-                0
-            ]
-        },
-        "class_type": "LatentUpscale"
-    },
-    "50": {
-        "inputs": {
-            "seed": 287046928977701,
-            "steps": 15,
-            "cfg": 8.0,
-            "sampler_name": "dpmpp_2m",
-            "scheduler": "simple",
-            "denoise": 0.6,
-            "model": [
-                "47",
-                0
-            ],
-            "positive": [
-                "24",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "49",
-                0
-            ]
-        },
-        "class_type": "KSampler"
-    },
-    "52": {
-        "inputs": {
-            "samples": [
-                "50",
-                0
-            ],
-            "vae": [
-                "47",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "52",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "20": {
+    "inputs": {
+      "image": "example.png",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "23": {
+    "inputs": {
+      "strength": 0.8500000000000003,
+      "conditioning": [
+        "24",
+        0
+      ],
+      "control_net": [
+        "33",
+        0
+      ],
+      "image": [
+        "34",
+        0
+      ]
+    },
+    "class_type": "ControlNetApply",
+    "_meta": {
+      "title": "controlnet_apply"
+    }
+  },
+  "24": {
+    "inputs": {
+      "text": "a man walking in the jungle\n\n\n",
+      "clip": [
+        "47",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "33": {
+    "inputs": {
+      "control_net_name": "control_scribble_fp16.safetensors",
+      "model": [
+        "47",
+        0
+      ]
+    },
+    "class_type": "DiffControlNetLoader",
+    "_meta": {
+      "title": "controlnet_model_loader"
+    }
+  },
+  "34": {
+    "inputs": {
+      "low_threshold": 100,
+      "high_threshold": 200,
+      "resolution": "disable",
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "CannyEdgePreprocessor",
+    "_meta": {
+      "title": "canny"
+    }
+  },
+  "37": {
+    "inputs": {
+      "rm_nearest": 0,
+      "rm_background": 0,
+      "boost": "disable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "LeReS-DepthMapPreprocessor",
+    "_meta": {
+      "title": "depth"
+    }
+  },
+  "39": {
+    "inputs": {
+      "safe": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "HEDPreprocessor",
+    "_meta": {
+      "title": "hed"
+    }
+  },
+  "40": {
+    "inputs": {
+      "a": 6.283185307179586,
+      "bg_threshold": 0.05,
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "MiDaS-NormalMapPreprocessor",
+    "_meta": {
+      "title": "normal"
+    }
+  },
+  "42": {
+    "inputs": {
+      "detect_hand": "disable",
+      "detect_body": "disable",
+      "detect_face": "disable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "OpenposePreprocessor",
+    "_meta": {
+      "title": "openpose"
+    }
+  },
+  "43": {
+    "inputs": {
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "SemSegPreprocessor",
+    "_meta": {
+      "title": "seg"
+    }
+  },
+  "44": {
+    "inputs": {
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "ScribblePreprocessor",
+    "_meta": {
+      "title": "scribble"
+    }
+  },
+  "45": {
+    "inputs": {
+      "safe": "enable",
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "FakeScribblePreprocessor",
+    "_meta": {
+      "title": "fakescribble"
+    }
+  },
+  "46": {
+    "inputs": {
+      "score_threshold": 0.15,
+      "dist_threshold": 1,
+      "resolution": 512,
+      "image": [
+        "20",
+        0
+      ]
+    },
+    "class_type": "M-LSDPreprocessor",
+    "_meta": {
+      "title": "mlsd"
+    }
+  },
+  "47": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "49": {
+    "inputs": {
+      "upscale_method": "nearest-exact",
+      "width": 768,
+      "height": 768,
+      "crop": "disabled",
+      "samples": [
+        "3",
+        0
+      ]
+    },
+    "class_type": "LatentUpscale",
+    "_meta": {
+      "title": "latent_upscale"
+    }
+  },
+  "50": {
+    "inputs": {
+      "seed": 287046928977701,
+      "steps": 15,
+      "cfg": 8,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "simple",
+      "denoise": 0.6,
+      "model": [
+        "47",
+        0
+      ],
+      "positive": [
+        "24",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "49",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "upscale_sampler"
+    }
+  },
+  "52": {
+    "inputs": {
+      "samples": [
+        "50",
+        0
+      ],
+      "vae": [
+        "47",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "vae_decode"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_controlnet_hires_fix.json
+++ b/hordelib/pipelines/pipeline_controlnet_hires_fix.json
@@ -1,328 +1,252 @@
 {
-  "3": {
-    "inputs": {
-      "seed": 123456789,
-      "steps": 25,
-      "cfg": 7.5,
-      "sampler_name": "dpmpp_2m",
-      "scheduler": "karras",
-      "denoise": 1,
-      "model": [
-        "47",
-        0
-      ],
-      "positive": [
-        "23",
-        0
-      ],
-      "negative": [
-        "7",
-        0
-      ],
-      "latent_image": [
-        "5",
-        0
-      ]
+    "3": {
+        "inputs": {
+            "seed": 123456789,
+            "steps": 25,
+            "cfg": 7.5,
+            "sampler_name": "dpmpp_2m",
+            "scheduler": "karras",
+            "denoise": 1.0,
+            "model": [
+                "47",
+                0
+            ],
+            "positive": [
+                "23",
+                0
+            ],
+            "negative": [
+                "7",
+                0
+            ],
+            "latent_image": [
+                "5",
+                0
+            ]
+        },
+        "class_type": "KSampler"
     },
-    "class_type": "KSampler",
-    "_meta": {
-      "title": "sampler"
-    }
-  },
-  "5": {
-    "inputs": {
-      "width": 512,
-      "height": 512,
-      "batch_size": 1
+    "5": {
+        "inputs": {
+            "width": 512,
+            "height": 512,
+            "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage"
     },
-    "class_type": "EmptyLatentImage",
-    "_meta": {
-      "title": "empty_latent_image"
-    }
-  },
-  "7": {
-    "inputs": {
-      "text": "",
-      "clip": [
-        "47",
-        1
-      ]
+    "7": {
+        "inputs": {
+            "text": "",
+            "clip": [
+                "47",
+                1
+            ]
+        },
+        "class_type": "CLIPTextEncode"
     },
-    "class_type": "CLIPTextEncode",
-    "_meta": {
-      "title": "negative_prompt"
-    }
-  },
-  "9": {
-    "inputs": {
-      "filename_prefix": "ComfyUI",
-      "images": [
-        "52",
-        0
-      ]
+    "9": {
+        "inputs": {
+            "filename_prefix": "ComfyUI",
+            "images": [
+                "52",
+                0
+            ]
+        },
+        "class_type": "SaveImage"
     },
-    "class_type": "SaveImage",
-    "_meta": {
-      "title": "output_image"
-    }
-  },
-  "20": {
-    "inputs": {
-      "image": "example.png",
-      "upload": "image"
+    "20": {
+        "inputs": {
+            "image": "test_db0 (2).jpg",
+            "choose file to upload": "image"
+        },
+        "class_type": "LoadImage"
     },
-    "class_type": "LoadImage",
-    "_meta": {
-      "title": "image_loader"
-    }
-  },
-  "23": {
-    "inputs": {
-      "strength": 0.8500000000000003,
-      "conditioning": [
-        "24",
-        0
-      ],
-      "control_net": [
-        "33",
-        0
-      ],
-      "image": [
-        "34",
-        0
-      ]
+    "23": {
+        "inputs": {
+            "strength": 0.8500000000000003,
+            "conditioning": [
+                "24",
+                0
+            ],
+            "control_net": [
+                "33",
+                0
+            ],
+            "image": [
+                "34",
+                0
+            ]
+        },
+        "class_type": "ControlNetApply"
     },
-    "class_type": "ControlNetApply",
-    "_meta": {
-      "title": "controlnet_apply"
-    }
-  },
-  "24": {
-    "inputs": {
-      "text": "a man walking in the jungle\n\n\n",
-      "clip": [
-        "47",
-        1
-      ]
+    "24": {
+        "inputs": {
+            "text": "a man walking in the jungle\n\n\n",
+            "clip": [
+                "47",
+                1
+            ]
+        },
+        "class_type": "CLIPTextEncode"
     },
-    "class_type": "CLIPTextEncode",
-    "_meta": {
-      "title": "prompt"
-    }
-  },
-  "33": {
-    "inputs": {
-      "control_net_name": "control_scribble_fp16.safetensors",
-      "model": [
-        "47",
-        0
-      ]
+    "33": {
+        "inputs": {
+            "control_net_name": "control_scribble_fp16.safetensors",
+            "model": [
+                "47",
+                0
+            ]
+        },
+        "class_type": "DiffControlNetLoader"
     },
-    "class_type": "DiffControlNetLoader",
-    "_meta": {
-      "title": "controlnet_model_loader"
-    }
-  },
-  "34": {
-    "inputs": {
-      "low_threshold": 100,
-      "high_threshold": 200,
-      "resolution": "disable",
-      "image": [
-        "20",
-        0
-      ]
+    "34": {
+        "inputs": {
+            "low_threshold": 100,
+            "high_threshold": 200,
+            "l2gradient": "disable",
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "CannyEdgePreprocessor"
     },
-    "class_type": "CannyEdgePreprocessor",
-    "_meta": {
-      "title": "canny"
-    }
-  },
-  "37": {
-    "inputs": {
-      "rm_nearest": 0,
-      "rm_background": 0,
-      "boost": "disable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "37": {
+        "inputs": {
+            "rm_nearest": 0,
+            "rm_background": 0,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "LeReS-DepthMapPreprocessor"
     },
-    "class_type": "LeReS-DepthMapPreprocessor",
-    "_meta": {
-      "title": "depth"
-    }
-  },
-  "39": {
-    "inputs": {
-      "safe": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "39": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "HEDPreprocessor"
     },
-    "class_type": "HEDPreprocessor",
-    "_meta": {
-      "title": "hed"
-    }
-  },
-  "40": {
-    "inputs": {
-      "a": 6.283185307179586,
-      "bg_threshold": 0.05,
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "40": {
+        "inputs": {
+            "a": 6.283185307179586,
+            "bg_threshold": 0.05,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "MiDaS-NormalMapPreprocessor"
     },
-    "class_type": "MiDaS-NormalMapPreprocessor",
-    "_meta": {
-      "title": "normal"
-    }
-  },
-  "42": {
-    "inputs": {
-      "detect_hand": "disable",
-      "detect_body": "disable",
-      "detect_face": "disable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "42": {
+        "inputs": {
+            "detect_hand": "disable",
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "OpenposePreprocessor"
     },
-    "class_type": "OpenposePreprocessor",
-    "_meta": {
-      "title": "openpose"
-    }
-  },
-  "43": {
-    "inputs": {
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "43": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "SemSegPreprocessor"
     },
-    "class_type": "SemSegPreprocessor",
-    "_meta": {
-      "title": "seg"
-    }
-  },
-  "44": {
-    "inputs": {
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "44": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "ScribblePreprocessor"
     },
-    "class_type": "ScribblePreprocessor",
-    "_meta": {
-      "title": "scribble"
-    }
-  },
-  "45": {
-    "inputs": {
-      "safe": "enable",
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "45": {
+        "inputs": {
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "FakeScribblePreprocessor"
     },
-    "class_type": "FakeScribblePreprocessor",
-    "_meta": {
-      "title": "fakescribble"
-    }
-  },
-  "46": {
-    "inputs": {
-      "score_threshold": 0.15,
-      "dist_threshold": 1,
-      "resolution": 512,
-      "image": [
-        "20",
-        0
-      ]
+    "46": {
+        "inputs": {
+            "score_threshold": 0.15,
+            "dist_threshold": 1,
+            "image": [
+                "20",
+                0
+            ]
+        },
+        "class_type": "M-LSDPreprocessor"
     },
-    "class_type": "M-LSDPreprocessor",
-    "_meta": {
-      "title": "mlsd"
-    }
-  },
-  "47": {
-    "inputs": {
-      "ckpt_name": "Deliberate.ckpt"
+    "47": {
+        "inputs": {
+            "ckpt_name": "Deliberate.ckpt"
+        },
+        "class_type": "CheckpointLoaderSimple"
     },
-    "class_type": "CheckpointLoaderSimple",
-    "_meta": {
-      "title": "model_loader"
-    }
-  },
-  "49": {
-    "inputs": {
-      "upscale_method": "nearest-exact",
-      "width": 768,
-      "height": 768,
-      "crop": "disabled",
-      "samples": [
-        "3",
-        0
-      ]
+    "49": {
+        "inputs": {
+            "upscale_method": "nearest-exact",
+            "width": 768,
+            "height": 768,
+            "crop": "disabled",
+            "samples": [
+                "3",
+                0
+            ]
+        },
+        "class_type": "LatentUpscale"
     },
-    "class_type": "LatentUpscale",
-    "_meta": {
-      "title": "latent_upscale"
-    }
-  },
-  "50": {
-    "inputs": {
-      "seed": 287046928977701,
-      "steps": 15,
-      "cfg": 8,
-      "sampler_name": "dpmpp_2m",
-      "scheduler": "simple",
-      "denoise": 0.6,
-      "model": [
-        "47",
-        0
-      ],
-      "positive": [
-        "24",
-        0
-      ],
-      "negative": [
-        "7",
-        0
-      ],
-      "latent_image": [
-        "49",
-        0
-      ]
+    "50": {
+        "inputs": {
+            "seed": 287046928977701,
+            "steps": 15,
+            "cfg": 8.0,
+            "sampler_name": "dpmpp_2m",
+            "scheduler": "simple",
+            "denoise": 0.6,
+            "model": [
+                "47",
+                0
+            ],
+            "positive": [
+                "24",
+                0
+            ],
+            "negative": [
+                "7",
+                0
+            ],
+            "latent_image": [
+                "49",
+                0
+            ]
+        },
+        "class_type": "KSampler"
     },
-    "class_type": "KSampler",
-    "_meta": {
-      "title": "upscale_sampler"
+    "52": {
+        "inputs": {
+            "samples": [
+                "50",
+                0
+            ],
+            "vae": [
+                "47",
+                2
+            ]
+        },
+        "class_type": "VAEDecode"
     }
-  },
-  "52": {
-    "inputs": {
-      "samples": [
-        "50",
-        0
-      ],
-      "vae": [
-        "47",
-        2
-      ]
-    },
-    "class_type": "VAEDecode",
-    "_meta": {
-      "title": "vae_decode"
-    }
-  }
 }

--- a/hordelib/pipelines/pipeline_image_facefix.json
+++ b/hordelib/pipelines/pipeline_image_facefix.json
@@ -45,6 +45,7 @@
     },
     "_meta": {
       "title": "face_restore_with_model"
-    }
+    },
+    "class_type": "FaceRestoreWithModel"
   }
 }

--- a/hordelib/pipelines/pipeline_image_facefix.json
+++ b/hordelib/pipelines/pipeline_image_facefix.json
@@ -1,39 +1,50 @@
 {
-    "1": {
-        "inputs": {
-            "image": "test_facefix.png",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
+  "1": {
+    "inputs": {
+      "image": "test_facefix.png",
+      "upload": "image"
     },
-    "4": {
-        "inputs": {
-            "model_name": "CodeFormers.pth"
-        },
-        "class_type": "UpscaleModelLoader"
-    },
-    "6": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "8",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "8": {
-        "inputs": {
-            "facedetection": "retinaface_resnet50",
-            "upscale_model": [
-                "4",
-                0
-            ],
-            "image": [
-                "1",
-                0
-            ]
-        },
-        "class_type": "FaceRestoreWithModel"
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
     }
+  },
+  "4": {
+    "inputs": {
+      "model_name": "CodeFormers.pth"
+    },
+    "class_type": "UpscaleModelLoader",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "6": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "8": {
+    "inputs": {
+      "facedetection": "retinaface_resnet50",
+      "upscale_model": [
+        "4",
+        0
+      ],
+      "image": [
+        "1",
+        0
+      ]
+    },
+    "_meta": {
+      "title": "face_restore_with_model"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_image_upscale.json
+++ b/hordelib/pipelines/pipeline_image_upscale.json
@@ -1,38 +1,50 @@
 {
-    "1": {
-        "inputs": {
-            "image": "ComfyUI_00010_.png",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
+  "1": {
+    "inputs": {
+      "image": "ComfyUI_00010_.png",
+      "upload": "image"
     },
-    "3": {
-        "inputs": {
-            "upscale_model": [
-                "4",
-                0
-            ],
-            "image": [
-                "1",
-                0
-            ]
-        },
-        "class_type": "ImageUpscaleWithModel"
-    },
-    "4": {
-        "inputs": {
-            "model_name": "NMKD_Siax.pth"
-        },
-        "class_type": "UpscaleModelLoader"
-    },
-    "6": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "3",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
     }
+  },
+  "3": {
+    "inputs": {
+      "upscale_model": [
+        "4",
+        0
+      ],
+      "image": [
+        "1",
+        0
+      ]
+    },
+    "class_type": "ImageUpscaleWithModel",
+    "_meta": {
+      "title": "Upscale Image (using Model)"
+    }
+  },
+  "4": {
+    "inputs": {
+      "model_name": "NMKD_Siax.pth"
+    },
+    "class_type": "UpscaleModelLoader",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "6": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "3",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_stable_diffusion.json
+++ b/hordelib/pipelines/pipeline_stable_diffusion.json
@@ -1,127 +1,159 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 843159458049729,
-            "steps": 20,
-            "cfg": 8.0,
-            "sampler_name": "euler",
-            "scheduler": "normal",
-            "denoise": 1.0,
-            "model": [
-                "4",
-                0
-            ],
-            "positive": [
-                "6",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "5",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 62706718437716,
+      "steps": 20,
+      "cfg": 8,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "4",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
     },
-    "4": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "5": {
-        "inputs": {
-            "width": 512,
-            "height": 512,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "6": {
-        "inputs": {
-            "text": "dinosaur ",
-            "clip": [
-                "10",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "7": {
-        "inputs": {
-            "text": "painting, drawing, artwork",
-            "clip": [
-                "10",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "14",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "10": {
-        "inputs": {
-            "stop_at_clip_layer": -1,
-            "clip": [
-                "4",
-                1
-            ]
-        },
-        "class_type": "CLIPSetLastLayer"
-    },
-    "11": {
-        "inputs": {
-            "image": "example.png",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "12": {
-        "inputs": {
-            "pixels": [
-                "15",
-                0
-            ],
-            "vae": [
-                "4",
-                2
-            ]
-        },
-        "class_type": "VAEEncode"
-    },
-    "14": {
-        "inputs": {
-            "samples": [
-                "3",
-                0
-            ],
-            "vae": [
-                "4",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
-    },
-    "15": {
-        "id": 15,
-        "inputs": {
-            "amount": 1,
-            "image": [
-                "11",
-                0
-            ]
-        },
-        "class_type": "RepeatImageBatch"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "4": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "dinosaur ",
+      "clip": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "painting, drawing, artwork",
+      "clip": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "14",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "10": {
+    "inputs": {
+      "stop_at_clip_layer": -1,
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPSetLastLayer",
+    "_meta": {
+      "title": "clip_skip"
+    }
+  },
+  "11": {
+    "inputs": {
+      "image": "example.png",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "12": {
+    "inputs": {
+      "pixels": [
+        "15",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "vae_encode"
+    }
+  },
+  "14": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "vae_decode"
+    }
+  },
+  "15": {
+    "inputs": {
+      "amount": 1,
+      "image": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "RepeatImageBatch",
+    "_meta": {
+      "title": "repeat_image_batch"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_stable_diffusion_hires_fix.json
+++ b/hordelib/pipelines/pipeline_stable_diffusion_hires_fix.json
@@ -1,167 +1,205 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 1096039238624618,
-            "steps": 12,
-            "cfg": 8.0,
-            "sampler_name": "dpmpp_sde",
-            "scheduler": "normal",
-            "denoise": 1.0,
-            "model": [
-                "16",
-                0
-            ],
-            "positive": [
-                "6",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "5",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 458841867575267,
+      "steps": 12,
+      "cfg": 8,
+      "sampler_name": "dpmpp_sde",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "16",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
     },
-    "5": {
-        "inputs": {
-            "width": 256,
-            "height": 256,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "6": {
-        "inputs": {
-            "text": "(masterpiece) HDR victorian portrait painting of (girl), blonde hair, mountain nature, blue sky\n",
-            "clip": [
-                "17",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "7": {
-        "inputs": {
-            "text": "bad hands, text, watermark\n",
-            "clip": [
-                "17",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "10": {
-        "inputs": {
-            "upscale_method": "nearest-exact",
-            "width": 512,
-            "height": 512,
-            "crop": "disabled",
-            "samples": [
-                "3",
-                0
-            ]
-        },
-        "class_type": "LatentUpscale"
-    },
-    "11": {
-        "inputs": {
-            "seed": 347776641452924,
-            "steps": 14,
-            "cfg": 8.0,
-            "sampler_name": "dpmpp_2m",
-            "scheduler": "simple",
-            "denoise": 0.5,
-            "model": [
-                "16",
-                0
-            ],
-            "positive": [
-                "6",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "10",
-                0
-            ]
-        },
-        "class_type": "KSampler"
-    },
-    "12": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "21",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "16": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "17": {
-        "inputs": {
-            "stop_at_clip_layer": -1,
-            "clip": [
-                "16",
-                1
-            ]
-        },
-        "class_type": "CLIPSetLastLayer"
-    },
-    "18": {
-        "inputs": {
-            "image": "example.png",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "19": {
-        "inputs": {
-            "pixels": [
-                "22",
-                0
-            ],
-            "vae": [
-                "16",
-                2
-            ]
-        },
-        "class_type": "VAEEncode"
-    },
-    "21": {
-        "inputs": {
-            "samples": [
-                "11",
-                0
-            ],
-            "vae": [
-                "16",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
-    },
-    "22": {
-        "id": 22,
-        "inputs": {
-            "amount": 1,
-            "image": [
-                "18",
-                0
-            ]
-        },
-        "class_type": "RepeatImageBatch"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "5": {
+    "inputs": {
+      "width": 256,
+      "height": 256,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "(masterpiece) HDR victorian portrait painting of (girl), blonde hair, mountain nature, blue sky\n",
+      "clip": [
+        "17",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "bad hands, text, watermark\n",
+      "clip": [
+        "17",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "10": {
+    "inputs": {
+      "upscale_method": "nearest-exact",
+      "width": 512,
+      "height": 512,
+      "crop": "disabled",
+      "samples": [
+        "3",
+        0
+      ]
+    },
+    "class_type": "LatentUpscale",
+    "_meta": {
+      "title": "latent_upscale"
+    }
+  },
+  "11": {
+    "inputs": {
+      "seed": 65484213431324,
+      "steps": 14,
+      "cfg": 8,
+      "sampler_name": "dpmpp_2m",
+      "scheduler": "simple",
+      "denoise": 0.5,
+      "model": [
+        "16",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "upscale_sampler"
+    }
+  },
+  "12": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "21",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "16": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "17": {
+    "inputs": {
+      "stop_at_clip_layer": -1,
+      "clip": [
+        "16",
+        1
+      ]
+    },
+    "class_type": "CLIPSetLastLayer",
+    "_meta": {
+      "title": "clip_skip"
+    }
+  },
+  "18": {
+    "inputs": {
+      "image": "example.png",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "19": {
+    "inputs": {
+      "pixels": [
+        "22",
+        0
+      ],
+      "vae": [
+        "16",
+        2
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "vae_encode"
+    }
+  },
+  "21": {
+    "inputs": {
+      "samples": [
+        "11",
+        0
+      ],
+      "vae": [
+        "16",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "vae_decode"
+    }
+  },
+  "22": {
+    "inputs": {
+      "amount": 1,
+      "image": [
+        "18",
+        0
+      ]
+    },
+    "class_type": "RepeatImageBatch",
+    "_meta": {
+      "title": "repeat_image_batch"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_stable_diffusion_img2img_mask.json
+++ b/hordelib/pipelines/pipeline_stable_diffusion_img2img_mask.json
@@ -1,140 +1,175 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 681890209860356,
-            "steps": 20,
-            "cfg": 8.0,
-            "sampler_name": "euler",
-            "scheduler": "normal",
-            "denoise": 0.46999999999999953,
-            "model": [
-                "4",
-                0
-            ],
-            "positive": [
-                "6",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "16",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 501193305970493,
+      "steps": 20,
+      "cfg": 8,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 0.46999999999999953,
+      "model": [
+        "4",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "16",
+        0
+      ]
     },
-    "4": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "5": {
-        "inputs": {
-            "width": 512,
-            "height": 512,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "6": {
-        "inputs": {
-            "text": "dinosaur ",
-            "clip": [
-                "10",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "7": {
-        "inputs": {
-            "text": "painting, drawing, artwork",
-            "clip": [
-                "10",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "15",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "10": {
-        "inputs": {
-            "stop_at_clip_layer": -1,
-            "clip": [
-                "4",
-                1
-            ]
-        },
-        "class_type": "CLIPSetLastLayer"
-    },
-    "11": {
-        "inputs": {
-            "image": "test_inpaint_alpha.png",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "15": {
-        "inputs": {
-            "samples": [
-                "3",
-                0
-            ],
-            "vae": [
-                "4",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
-    },
-    "16": {
-        "inputs": {
-            "samples": [
-                "17",
-                0
-            ],
-            "mask": [
-                "11",
-                1
-            ]
-        },
-        "class_type": "SetLatentNoiseMask"
-    },
-    "17": {
-        "inputs": {
-            "pixels": [
-                "20",
-                0
-            ],
-            "vae": [
-                "4",
-                2
-            ]
-        },
-        "class_type": "VAEEncode"
-    },
-    "20": {
-        "id": 20,
-        "inputs": {
-            "amount": 1,
-            "image": [
-                "11",
-                0
-            ]
-        },
-        "class_type": "RepeatImageBatch"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "4": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "dinosaur ",
+      "clip": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "painting, drawing, artwork",
+      "clip": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "15",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "10": {
+    "inputs": {
+      "stop_at_clip_layer": -1,
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPSetLastLayer",
+    "_meta": {
+      "title": "clip_skip"
+    }
+  },
+  "11": {
+    "inputs": {
+      "image": "test_inpaint_alpha.png",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "15": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "16": {
+    "inputs": {
+      "samples": [
+        "17",
+        0
+      ],
+      "mask": [
+        "11",
+        1
+      ]
+    },
+    "class_type": "SetLatentNoiseMask",
+    "_meta": {
+      "title": "set_latent_noise_mask"
+    }
+  },
+  "17": {
+    "inputs": {
+      "pixels": [
+        "20",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "vae_encode_for_mask"
+    }
+  },
+  "20": {
+    "inputs": {
+      "amount": 1,
+      "image": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "RepeatImageBatch",
+    "_meta": {
+      "title": "repeat_image_batch"
+    }
+  }
 }

--- a/hordelib/pipelines/pipeline_stable_diffusion_paint.json
+++ b/hordelib/pipelines/pipeline_stable_diffusion_paint.json
@@ -1,132 +1,164 @@
 {
-    "3": {
-        "inputs": {
-            "seed": 77570063643350,
-            "steps": 20,
-            "cfg": 8.0,
-            "sampler_name": "euler",
-            "scheduler": "normal",
-            "denoise": 1.0,
-            "model": [
-                "4",
-                0
-            ],
-            "positive": [
-                "6",
-                0
-            ],
-            "negative": [
-                "7",
-                0
-            ],
-            "latent_image": [
-                "14",
-                0
-            ]
-        },
-        "class_type": "KSampler"
+  "3": {
+    "inputs": {
+      "seed": 845153640392169,
+      "steps": 20,
+      "cfg": 8,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "4",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "14",
+        0
+      ]
     },
-    "4": {
-        "inputs": {
-            "ckpt_name": "Deliberate.ckpt"
-        },
-        "class_type": "CheckpointLoaderSimple"
-    },
-    "5": {
-        "inputs": {
-            "width": 512,
-            "height": 512,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage"
-    },
-    "6": {
-        "inputs": {
-            "text": "dinosaur ",
-            "clip": [
-                "10",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "7": {
-        "inputs": {
-            "text": "painting, drawing, artwork",
-            "clip": [
-                "10",
-                0
-            ]
-        },
-        "class_type": "CLIPTextEncode"
-    },
-    "9": {
-        "inputs": {
-            "filename_prefix": "ComfyUI",
-            "images": [
-                "15",
-                0
-            ]
-        },
-        "class_type": "SaveImage"
-    },
-    "10": {
-        "inputs": {
-            "stop_at_clip_layer": -1,
-            "clip": [
-                "4",
-                1
-            ]
-        },
-        "class_type": "CLIPSetLastLayer"
-    },
-    "11": {
-        "inputs": {
-            "image": "test_inpaint_alpha.png",
-            "choose file to upload": "image"
-        },
-        "class_type": "LoadImage"
-    },
-    "14": {
-        "inputs": {
-            "grow_mask_by": 6,
-            "pixels": [
-                "16",
-                0
-            ],
-            "vae": [
-                "4",
-                2
-            ],
-            "mask": [
-                "11",
-                1
-            ]
-        },
-        "class_type": "VAEEncodeForInpaint"
-    },
-    "15": {
-        "inputs": {
-            "samples": [
-                "3",
-                0
-            ],
-            "vae": [
-                "4",
-                2
-            ]
-        },
-        "class_type": "VAEDecode"
-    },
-    "16": {
-        "id": 16,
-        "inputs": {
-            "amount": 1,
-            "image": [
-                "11",
-                0
-            ]
-        },
-        "class_type": "RepeatImageBatch"
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
     }
+  },
+  "4": {
+    "inputs": {
+      "ckpt_name": "Deliberate.ckpt"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "dinosaur ",
+      "clip": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "painting, drawing, artwork",
+      "clip": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "15",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  },
+  "10": {
+    "inputs": {
+      "stop_at_clip_layer": -1,
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPSetLastLayer",
+    "_meta": {
+      "title": "clip_skip"
+    }
+  },
+  "11": {
+    "inputs": {
+      "image": "test_inpaint_alpha.png",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "image_loader"
+    }
+  },
+  "14": {
+    "inputs": {
+      "grow_mask_by": 6,
+      "pixels": [
+        "16",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ],
+      "mask": [
+        "11",
+        1
+      ]
+    },
+    "class_type": "VAEEncodeForInpaint",
+    "_meta": {
+      "title": "vae_encode"
+    }
+  },
+  "15": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "16": {
+    "inputs": {
+      "amount": 1,
+      "image": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "RepeatImageBatch",
+    "_meta": {
+      "title": "repeat_image_batch"
+    }
+  }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,6 @@ def init_horde(
         if not os.path.exists(default_custom_model_json_path):
             os.makedirs(os.path.dirname(default_custom_model_json_path), exist_ok=True)
             with open(default_custom_model_json_path, "w") as f:
-
                 json.dump(default_custom_model_json, f, indent=4)
 
         os.environ["HORDELIB_CUSTOM_MODELS"] = default_custom_model_json_path

--- a/tests/test_comfy.py
+++ b/tests/test_comfy.py
@@ -74,7 +74,7 @@ class TestComfyInterfaceCompatibility:
 
     def test_fix_node_names(self, hordelib_instance: HordeLib):
         # basically we are expecting a search and replace of "1" with the "title" of id 1, etc.
-        data = {
+        data: dict = {
             "1": {
                 "inputs": {
                     "input1": ["2", 0],

--- a/tests/test_comfy.py
+++ b/tests/test_comfy.py
@@ -83,6 +83,7 @@ class TestComfyInterfaceCompatibility:
                     "input4": 33,
                     "input5": None,
                 },
+                "_meta": {"title": "Node1"},
             },
             "2": {
                 "inputs": {
@@ -92,6 +93,7 @@ class TestComfyInterfaceCompatibility:
                     "input4": 33,
                     "input5": None,
                 },
+                "_meta": {"title": "Node2"},
             },
             "3": {
                 "inputs": {
@@ -103,14 +105,7 @@ class TestComfyInterfaceCompatibility:
                 },
             },
         }
-        design = {
-            "nodes": [
-                {"id": 1, "title": "Node1"},
-                {"id": 2, "title": "Node2"},
-                {"id": 3, "no_title": "Node3"},
-            ],
-        }
-        data = hordelib_instance.generator._fix_node_names(data, design)
+        data = hordelib_instance.generator._fix_node_names(data)
 
         assert data
         assert isinstance(data, dict)


### PR DESCRIPTION
* Uses the exported "_meta" field to get the pipeline node name, instead of requiring a design_pipeline.
* The design pipelines are left there for future reimport into comfy UI and adjustments, but have no other functional use.