### PR TITLE
Changed gen_metadata to work for requests with post_processors

### DIFF
--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -1476,7 +1476,7 @@ class HordeLib:
 
             post_processed = []
             for ret in return_list:
-                single_image_faults = []
+                single_image_faults = faults[:]
                 final_image = ret.image
                 final_rawpng = ret.rawpng
 


### PR DESCRIPTION
I believe this fix is correct, but I don't have a local version I can easily test with.

I also don't know enough about the underlying system to know if there are any side-effects caused by this...

But generally speaking, it looks like each image runs the post_processors and stores the gen_metadata for those in the variable single_image_faults. But we previously could have already had faults from bad LoRAs or other reasons. Those were getting lost and replaced by the list of post_processor messages.