### PR TITLE
feat: force full gpu load; feat: expose `interrupt_current_processing` from comfyui 

### DIFF
--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -40,9 +40,10 @@ from hordelib.config_path import get_hordelib_path
 # There may be other ways to skin this cat, but this strategy minimizes certain kinds of hassle.
 #
 # If you tamper with the code in this module to bring the imports out of the function, you may find that you have
-# broken, among other things, the ability of pytest to do its test discovery because you will have lost the ability for
-# modules which, directly or otherwise, import this module without having called `hordelib.initialise()`. Pytest
-# discovery will come across those imports, valiantly attempt to import them and fail with a cryptic error message.
+# broken, among myriad other things, the ability of pytest to do its test discovery because you will have lost the
+# ability for modules which, directly or otherwise, import this module without having called `hordelib.initialise()`.
+# Pytest discovery will come across those imports, valiantly attempt to import them and fail with a cryptic error
+# message.
 #
 # Correspondingly, you will find that to be an enormous hassle if you are are trying to leverage pytest in any
 # reasonability sophisticated way (outside of tox), and you will be forced to adopt solution below or something
@@ -51,17 +52,18 @@ from hordelib.config_path import get_hordelib_path
 #
 # Keen readers may have noticed that the aforementioned issues could be side stepped by simply calling
 # `hordelib.initialise()` automatically, such as in `test/__init__.py` or in a `conftest.py`. You would be correct,
-# but that would be a terrible idea if you ever intended to make alterations to the patch file, as each time you
-# triggered pytest discovery which could be as frequently as *every time you save a file* (such as with VSCode), and
-# you would enter a situation where the patch was automatically being applied at times you may not intend.
+# but that would be a terrible idea as a general practice. It would mean that every time you saved a file in your
+# editor, a number of heavyweight operations would be triggered, such as loading comfyui, while pytest discovery runs
+# and that would cause slow and unpredictable behavior in your editor.
 #
-# This would be a nightmare to debug, as this author is able to attest to.
+# This would be a nightmare to debug, as this author is able to attest to and is the reason this wall of text exists.
 #
 # Further, if you are like myself, and enjoy type hints, you will find that any modules have this file in their import
 # chain will be un-importable in certain contexts and you would be unable to provide the relevant type hints.
 #
-# Having read this, I suggest you glance at the code in `hordelib.initialise()` to get a sense of what is going on
-# there, and if you're still confused, ask a hordelib dev who would be happy to share the burden of understanding.
+# Having exercised a herculean amount of focus to read this far, I suggest you also glance at the code in
+# `hordelib.initialise()` to get a sense of what is going on there, and if you're still confused, ask a hordelib dev
+# who would be happy to share the burden of understanding.
 
 _comfy_load_models_gpu: types.FunctionType
 _comfy_current_loaded_models: list = None  # type: ignore

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -96,6 +96,8 @@ _comfy_soft_empty_cache: Callable[[bool], None]
 _comfy_is_changed_cache_get: Callable
 _comfy_model_patcher_load: Callable
 
+_comfy_interrupt_current_processing: types.FunctionType
+
 _canny: types.ModuleType
 _hed: types.ModuleType
 _leres: types.ModuleType
@@ -158,6 +160,8 @@ def do_comfy_import(
     global _comfy_free_memory, _comfy_cleanup_models, _comfy_soft_empty_cache
     global _canny, _hed, _leres, _midas, _mlsd, _openpose, _pidinet, _uniformer
 
+    global _comfy_interrupt_current_processing
+
     if disable_smart_memory:
         logger.info("Disabling smart memory")
         sys.argv.append("--disable-smart-memory")
@@ -206,6 +210,7 @@ def do_comfy_import(
         from comfy.model_management import free_memory as _comfy_free_memory
         from comfy.model_management import cleanup_models as _comfy_cleanup_models
         from comfy.model_management import soft_empty_cache as _comfy_soft_empty_cache
+        from comfy.model_management import interrupt_current_processing as _comfy_interrupt_current_processing
         from comfy.utils import load_torch_file as _comfy_load_torch_file
         from comfy_extras.chainner_models import model_loading as _comfy_model_loading
 
@@ -377,6 +382,11 @@ def log_free_ram():
         f"Free VRAM: {get_torch_free_vram_mb():0.0f} MB, "
         f"Free RAM: {psutil.virtual_memory().available / (1024 * 1024):0.0f} MB",
     )
+
+
+def interrupt_comfyui_processing():
+    logger.warning("Interrupting comfyui processing")
+    _comfy_interrupt_current_processing()
 
 
 class Comfy_Horde:

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -427,6 +427,7 @@ class Comfy_Horde:
         self,
         *,
         comfyui_callback: typing.Callable[[str, dict, str], None] | None = None,
+        aggressive_unloading: bool = True,
     ) -> None:
         """Initialise the Comfy_Horde object.
 
@@ -453,6 +454,7 @@ class Comfy_Horde:
         self._load_custom_nodes()
 
         self._comfyui_callback = comfyui_callback
+        self.aggressive_unloading = aggressive_unloading
 
     def _set_comfyui_paths(self) -> None:
         # These set the default paths for comfyui to look for models and embeddings. From within hordelib,
@@ -829,6 +831,12 @@ class Comfy_Horde:
                     inference.execute(pipeline, self.client_id, {"client_id": self.client_id}, valid[2])
             except Exception as e:
                 logger.exception(f"Exception during comfy execute: {e}")
+            finally:
+                if self.aggressive_unloading:
+                    global _comfy_cleanup_models
+                    logger.debug("Cleaning up models")
+                    _comfy_cleanup_models(False)
+                    _comfy_soft_empty_cache(True)
 
         stdio.replay()
 

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -121,6 +121,9 @@ class InterceptHandler(logging.Handler):
 
     @logger.catch(default=True, reraise=True)
     def emit(self, record):
+        message = record.getMessage()
+        if "lowvram: loaded module regularly" in message:
+            return
         # Get corresponding Loguru level if it exists.
         try:
             level = logger.level(record.levelname).name
@@ -133,7 +136,7 @@ class InterceptHandler(logging.Handler):
             frame = frame.f_back
             depth += 1
 
-        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+        logger.opt(depth=depth, exception=record.exc_info).log(level, message)
 
 
 # ComfyUI uses stdlib logging, so we need to intercept it.

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -352,7 +352,7 @@ class HordeLib:
         self,
         *,
         comfyui_callback: Callable[[str, dict, str], None] | None = None,
-        aggressive_unloading: bool = False,
+        aggressive_unloading: bool = True,
     ):
         if not self._initialised:
             self.generator = Comfy_Horde(

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -352,10 +352,12 @@ class HordeLib:
         self,
         *,
         comfyui_callback: Callable[[str, dict, str], None] | None = None,
+        aggressive_unloading: bool = False,
     ):
         if not self._initialised:
             self.generator = Comfy_Horde(
                 comfyui_callback=comfyui_callback if comfyui_callback else self._comfyui_callback,
+                aggressive_unloading=aggressive_unloading,
             )
             self.__class__._initialised = True
 

--- a/hordelib/initialisation.py
+++ b/hordelib/initialisation.py
@@ -28,6 +28,7 @@ def initialise(
     extra_comfyui_args: list[str] | None = None,
     disable_smart_memory: bool = False,
     do_not_load_model_mangers: bool = False,
+    models_not_to_force_load: list[str] | None = None,
 ):
     """Initialise hordelib. This is required before using any other hordelib functions.
 
@@ -39,6 +40,9 @@ def initialise(
             Defaults to None.
         force_low_vram (bool, optional): Whether to forcibly disable ComfyUI's high/med vram modes. Defaults to False.
         extra_comfyui_args (list[str] | None, optional): Any additional CLI args for comfyui that should be used. \
+            Defaults to None.
+        models_not_to_force_load (list[str] | None, optional): A list of baselines that should not be force loaded.\
+            **If this is `None`, the defaults are used.** If you wish to override the defaults, pass an empty list. \
             Defaults to None.
     """
     global _is_initialised
@@ -79,6 +83,8 @@ def initialise(
         extra_comfyui_args=extra_comfyui_args,
         disable_smart_memory=disable_smart_memory,
     )
+    if models_not_to_force_load is not None:
+        hordelib.comfy_horde.models_not_to_force_load = models_not_to_force_load.copy()
 
     vram_on_start_free = hordelib.comfy_horde.get_torch_free_vram_mb()
     vram_total = hordelib.comfy_horde.get_torch_total_vram_mb()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def init_horde(
     hordelib.initialise(
         setup_logging=True,
         logging_verbosity=5,
-        disable_smart_memory=False,
+        disable_smart_memory=True,
         force_normal_vram_mode=True,
         do_not_load_model_mangers=True,
         models_not_to_force_load=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,12 @@ def init_horde(
         setup_logging=True,
         logging_verbosity=5,
         disable_smart_memory=False,
+        force_normal_vram_mode=True,
         do_not_load_model_mangers=True,
+        models_not_to_force_load=[
+            "sdxl",
+            "cascade",
+        ],
     )
     from hordelib.settings import UserSettings
 

--- a/tests/test_horde_inference.py
+++ b/tests/test_horde_inference.py
@@ -48,6 +48,43 @@ class TestHordeInference:
         )
 
     @pytest.mark.default_sd15_model
+    def test_text_to_image_max_resolution(
+        self,
+        hordelib_instance: HordeLib,
+        stable_diffusion_model_name_for_testing: str,
+    ):
+        data = {
+            "sampler_name": "k_dpmpp_2m",
+            "cfg_scale": 7.5,
+            "denoising_strength": 1.0,
+            "seed": 123456789,
+            "height": 2048,
+            "width": 2048,
+            "karras": False,
+            "tiling": False,
+            "hires_fix": False,
+            "clip_skip": 1,
+            "control_type": None,
+            "image_is_control": False,
+            "return_control_map": False,
+            "prompt": "an ancient llamia monster",
+            "ddim_steps": 5,
+            "n_iter": 1,
+            "model": stable_diffusion_model_name_for_testing,
+        }
+        pil_image = hordelib_instance.basic_inference_single_image(data).image
+        assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
+
+        img_filename = "text_to_image_max_resolution.png"
+        pil_image.save(f"images/{img_filename}", quality=100)
+
+        assert check_single_inference_image_similarity(
+            f"images_expected/{img_filename}",
+            pil_image,
+        )
+
+    @pytest.mark.default_sd15_model
     def test_text_to_image_n_iter(
         self,
         hordelib_instance: HordeLib,


### PR DESCRIPTION
After what feels like an eternity of troubleshooting, I have determined the following:

- [fix: force models loading to the GPU to be gpu-only](https://github.com/Haidra-Org/hordelib/commit/4e99a015703145c7203375cda2d2939b57cc26ae)
  - ComfyUI was too likely to only partially load the models to the GPU. This had **major** performance implications. The comfyui hard-coded numbers which underpin the logic do not consider the worker use case and is overly cautious when speed is the chief consideration. I'm sure this change has the potential to increase worker instability but I have seen a 10%-15% increase in throughput on my 2080 when used via the worker with this change, so I am going to at least try and get this to work. There are a number of techniques the worker can use (manually clearing memory or even killing a process) to manage this, so I believe it should be possible to make this viable.
- [feat: aggressive_unloading for more regular garbage collection](https://github.com/Haidra-Org/hordelib/commit/29b4e81030c5653b671c78d967482e48b1fa1bf2)
  - ComfyUI's default mode of running (`main.py`) includes calls to `cleanup_models(...)` and `soft_empty_cache(...)` on a timer. I suspect issues that have arisen lately are rooted in the fact that horde-engine does not currently do something similar. I am adding this (default on) option to the `HordeLib` class to call these after every pipeline run.
