### PR TITLE
feat: comfyui `73e3a9e6`; torch >=2.5.0 by default

### DIFF
--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -6,7 +6,7 @@ from strenum import StrEnum
 
 from hordelib.config_path import get_hordelib_path
 
-COMFYUI_VERSION = "3bb4dec720bd3be13a6fd381f641929386476efc"
+COMFYUI_VERSION = "73e3a9e67654d5b20054da02c6a77311af527364"
 """The exact version of ComfyUI version to load."""
 
 REMOTE_PROXY = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ horde_sdk>=0.15.0
 horde_model_reference>=0.9.1
 pydantic
 numpy==1.26.4
-torch>=2.4.1
+torch>=2.5.0
 # xformers>=0.0.19
 torchvision
 # torchaudio


### PR DESCRIPTION
- See the diff for ComfyUI from the last update here: https://github.com/comfyanonymous/ComfyUI/compare/3bb4dec720bd3be13a6fd381f641929386476efc...73e3a9e67654d5b20054da02c6a77311af527364
- Use latest stable torch by default, which is 2.5.0 at the time of writing.