### PR TITLE
fix: set torch 2.4.1 for rocm compat for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ horde_sdk>=0.15.0
 horde_model_reference>=0.9.1
 pydantic
 numpy==1.26.4
-torch>=2.5.0
+torch>=2.4.1
 # xformers>=0.0.19
 torchvision
 # torchaudio


### PR DESCRIPTION
This is to account for limited RoCM support for torch 2.5 at the time of writing.