### PR TITLE
Added early stopping to train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -594,7 +594,7 @@ def objective(trial):
                 break
 
     # reload the best performing model we found
-    model.load(best_state_dict)
+    model.load_state_dict(best_state_dict)
 
     # Pickle it as we'll forget the model architecture
     filename = f"kudos_models/kudos-{STUDY_VERSION}-{trial.number}.ckpt"

--- a/train.py
+++ b/train.py
@@ -601,7 +601,7 @@ def objective(trial):
     with open(filename, "wb") as outfile:
         pickle.dump(model.to("cpu"), outfile)
 
-    return total_loss
+    return best_loss
 
 
 def main():

--- a/train.py
+++ b/train.py
@@ -588,7 +588,7 @@ def objective(trial):
             best_epoch = epoch
             best_state_dict = model.state_dict()
         else:
-            epochs_since_best = current_epoch - best_epoch
+            epochs_since_best = epoch - best_epoch
             if epochs_since_best >= PATIENCE:
                 # Stop early, no improvement in awhile
                 break


### PR DESCRIPTION
This should stop after `PATIENCE` epochs beyond the current best performing epoch (I set this to 25 arbitrarily). So if we peak at epoch 60, it would run until 85 and then stop early if none of 61-85 performed better than 60 did. 

It also now saves the state_dict of the best performing epoch and saves that instead of the last one.