### PR TITLE
fix: rembg requires explicit runtime flag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ typing-extensions
 distro
 python-dotenv
 strenum
-rembg
+rembg[cpu]
 # image similarity + face fixer custom nodes
 opencv-python
 # controlnet custom nodes


### PR DESCRIPTION
Previously, CPU was the default, but it now requires explicitly specifying CPU/GPU. Historically, I have been unable to get GPU support to work easily. For now, I am going to keep the status quo to avoid causing other problems.