### PR TITLE
fix: ensure adhoc loras can be rotated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ tmp/
 *.pth
 .gitignore
 pipeline_debug.json
+inference-time-data*
+kudos_models/
+optuna_stud*.db

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -90,7 +90,7 @@ _comfy_free_memory: Callable[[float, torch.device, list], None]
 """Will aggressively unload models from memory"""
 _comfy_cleanup_models: Callable[[bool], None]
 """Will unload unused models from memory"""
-_comfy_soft_empty_cache: Callable[[bool], None]
+_comfy_soft_empty_cache: Callable
 """Triggers comfyui and torch to empty their caches"""
 
 _comfy_is_changed_cache_get: Callable

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -1,4 +1,3 @@
-import copy
 import glob
 import hashlib
 import json
@@ -960,6 +959,10 @@ class LoraModelManager(BaseModelManager):
                 logger.warning(f"Expected to delete lora file {lora_filename} but it was not found.")
         return loras_to_delete
 
+    def delete_adhoc_loras_over_limit(self):
+        while self.is_adhoc_cache_full():
+            self.delete_oldest_lora()
+
     def delete_lora_files(self, lora_filename: str):
         filename = os.path.join(self.model_folder_path, lora_filename)
         if not os.path.exists(filename):
@@ -1044,7 +1047,7 @@ class LoraModelManager(BaseModelManager):
         self.save_cached_reference_to_disk()
         logger.debug(
             f"Finished lora reset. Added {len(self._adhoc_loras)} adhoc loras "
-            f"with a total size of {self.calculate_adhoc_loras_cache()}"
+            f"with a total size of {self.calculate_adhoc_loras_cache()}",
         )
 
     def get_lora_metadata(self, url: str) -> dict:

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -893,7 +893,7 @@ class LoraModelManager(BaseModelManager):
         if not self.is_adhoc_cache_full():
             return 0
         # If we have exceeded our cache, we delete 1 lora + 1 extra lora per 4G over our cache.
-        return 1 + ((self.calculate_adhoc_loras_cache() - self._max_top_disk) / 4096)
+        return 1 + int((self.calculate_adhoc_loras_cache() - self.max_adhoc_disk) / 4096)
 
     def calculate_download_queue(self):
         total_queue = 0


### PR DESCRIPTION
Adds accelerator on delete if the cache starts bloating

Set adhoc loras from the previous json and doesn't just "forget" adhoc loras which were exceeding the size. The expectation is that the delete accelerator will be deleting the extra loras is the size gets changed in the settings.

Adds `delete_adhoc_loras_over_limit()` which should be called along with download_models as it only deletes known adhoc loras over the limit.