### PR TITLE
feat: comfyui `7a7efe8`

### DIFF
--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -88,7 +88,7 @@ _comfy_load_torch_file: types.FunctionType
 _comfy_model_loading: types.ModuleType
 _comfy_free_memory: Callable[[float, torch.device, list], None]
 """Will aggressively unload models from memory"""
-_comfy_cleanup_models: Callable[[bool], None]
+_comfy_cleanup_models: Callable[[None], None]
 """Will unload unused models from memory"""
 _comfy_soft_empty_cache: Callable
 """Triggers comfyui and torch to empty their caches"""
@@ -944,7 +944,7 @@ class Comfy_Horde:
                 if self.aggressive_unloading:
                     global _comfy_cleanup_models
                     logger.debug("Cleaning up models")
-                    _comfy_cleanup_models(False)
+                    _comfy_cleanup_models()
                     _comfy_soft_empty_cache()
 
         stdio.replay()

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -88,7 +88,7 @@ _comfy_load_torch_file: types.FunctionType
 _comfy_model_loading: types.ModuleType
 _comfy_free_memory: Callable[[float, torch.device, list], None]
 """Will aggressively unload models from memory"""
-_comfy_cleanup_models: Callable[[None], None]
+_comfy_cleanup_models: Callable
 """Will unload unused models from memory"""
 _comfy_soft_empty_cache: Callable
 """Triggers comfyui and torch to empty their caches"""

--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -6,7 +6,7 @@ from strenum import StrEnum
 
 from hordelib.config_path import get_hordelib_path
 
-COMFYUI_VERSION = "839ed3368efd0f61a2b986f57fe9e0698fd08e9f"
+COMFYUI_VERSION = "7a7efe8424d960a95be393a85ca4d94e5892edea"
 """The exact version of ComfyUI version to load."""
 
 REMOTE_PROXY = ""

--- a/hordelib/nodes/comfyui_layerdiffuse/lib_layerdiffusion/attention_sharing.py
+++ b/hordelib/nodes/comfyui_layerdiffuse/lib_layerdiffusion/attention_sharing.py
@@ -296,7 +296,7 @@ class HookerLayers(torch.nn.Module):
 class AttentionSharingPatcher(torch.nn.Module):
     def __init__(self, unet, frames=2, use_control=True, rank=256):
         super().__init__()
-        model_management.unload_model_clones(unet)
+        # model_management.unload_model_clones(unet) # this is now handled implicitly in comfyui
 
         units = []
         for i in range(32):

--- a/hordelib/pipeline_designs/pipeline_stable_cascade_remix.json
+++ b/hordelib/pipeline_designs/pipeline_stable_cascade_remix.json
@@ -460,7 +460,10 @@
       "title": "clip_vision_encode_0",
       "properties": {
         "Node name for S&R": "CLIPVisionEncode"
-      }
+      },
+      "widgets_values": [
+        "none"
+      ]
     },
     {
       "id": 51,

--- a/hordelib/pipelines/pipeline_stable_cascade_remix.json
+++ b/hordelib/pipelines/pipeline_stable_cascade_remix.json
@@ -171,7 +171,8 @@
     }
   },
   "50": {
-    "inputs": {
+    "inputs": {      
+      "crop": "none",
       "clip_vision": [
         "49",
         3

--- a/hordelib/pipelines/pipeline_stable_cascade_remix.json
+++ b/hordelib/pipelines/pipeline_stable_cascade_remix.json
@@ -171,7 +171,7 @@
     }
   },
   "50": {
-    "inputs": {      
+    "inputs": {
       "crop": "none",
       "clip_vision": [
         "49",


### PR DESCRIPTION
- See the diff for ComfyUI from the last update here: https://github.com/comfyanonymous/ComfyUI/compare/839ed3368efd0f61a2b986f57fe9e0698fd08e9f...7a7efe8424d960a95be393a85ca4d94e5892edea
  - Notably, there are improvements to memory management which I hope will help with the issues noted in  https://github.com/Haidra-Org/horde-worker-reGen/issues/316 
- `cleanup_models`'s signature has changed to have no arguments.
- The ClipVisionEncode node now requires a new argument, `crop`. I have set this to default to `"none"` in all circumstances as this seem to give the old behavior, though I suspect either value may be OK given the way we use these workflows.