### PR TITLE
feat: comfyui 73e0498; fix: cascade remix

### DIFF
--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -6,7 +6,7 @@ from strenum import StrEnum
 
 from hordelib.config_path import get_hordelib_path
 
-COMFYUI_VERSION = "7a7efe8424d960a95be393a85ca4d94e5892edea"
+COMFYUI_VERSION = "73e04987f7e0f14bdee9baa0aafe61cf7f42a8b2"
 """The exact version of ComfyUI version to load."""
 
 REMOTE_PROXY = ""

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -1037,6 +1037,7 @@ class HordeLib:
                     "inputs": {
                         "clip_vision": ["model_loader_stage_c", 3],
                         "image": [f"sc_image_loader_{node_index}", 0],
+                        "crop": "center",
                     },
                     "class_type": "CLIPVisionEncode",
                 }

--- a/hordelib/pipelines/pipeline_stable_cascade_remix.json
+++ b/hordelib/pipelines/pipeline_stable_cascade_remix.json
@@ -172,7 +172,7 @@
   },
   "50": {
     "inputs": {
-      "crop": "none",
+      "crop": "center",
       "clip_vision": [
         "49",
         3


### PR DESCRIPTION
- [feat: comfyui-73e0498](https://github.com/Haidra-Org/hordelib/commit/39aea7e07594fa033074d2aa1db521feb6cdfeb1)
  - See the diff for ComfyUI from the last update here:   https://github.com/comfyanonymous/ComfyUI/compare/7a7efe8424d960a95be393a85ca4d94e5892edea...73e04987f7e0f14bdee9baa0aafe61cf7f42a8b2

- [fix: cascade clip vision crop arg mapping](https://github.com/Haidra-Org/hordelib/commit/3da9b76b657759c826209b1e115eab805eeef0fa) 

  - An initial attempt at fixing was made in https://github.com/Haidra-Org/hordelib/commit/1a09ddf6b9e6f199d7905ab81b59b490bfbed5dd, the dynamic mapping of inputs for cascade remix (as is in the case with multiple input images) was not being handled appropriately. The new nodes created by horde-engine did not (re)create the `crop` argument for the CLIPVisionEncode node.

  - Additionally, it appears that `"crop": "center"` is the backwards-compatible change