### PR TITLE
fix: aggressively unload other models w/ large models

### DIFF
--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -329,6 +329,7 @@ def _load_models_gpu_hijack(*args, **kwargs):
     global _comfy_current_loaded_models
     if found_model_to_skip:
         logger.debug("Not overriding model load")
+        kwargs["memory_required"] = 1e30
         _comfy_load_models_gpu(*args, **kwargs)
         return
 


### PR DESCRIPTION
This should allow adjunct models, such as clip models, to be unloaded when large models are in play. This is in response to my observation that flux's clip model tends to stay in memory now on my 8gb card, but previously would smartly unload just prior to inference (and just after clip encoding). By setting a high `memory_required` I am hoping this will force this desired behavior.