### PR TITLE
fix: handle 'EarlyAccess' loras on civitai

### DIFF
--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -579,11 +579,11 @@ class LoraModelManager(BaseModelManager):
                         f"Retry {retries}/{self.MAX_RETRIES}",
                     )
 
-                    # If this is a 401, we're not going to get anywhere, just just give up
-                    if isinstance(e, requests.HTTPError) and e.response.status_code == 401:
+                    # If this is a 401 or 403, we're not going to get anywhere, just just give up
+                    if isinstance(e, requests.HTTPError) and e.response.status_code in [401, 403]:
                         logger.error(
                             f"Error downloading {lora['versions'][version]['filename']}. "
-                            "CivitAI appears to be redirecting us to a login page. Aborting",
+                            "CivitAI appears to be denying access. Aborting",
                         )
                         break
 

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -433,6 +433,7 @@ class LoraModelManager(BaseModelManager):
                 lora["versions"][lora_version]["version_id"] = self.ensure_is_version(version.get("id", 0))
                 # To be able to refer back to the parent if needed
                 lora["versions"][lora_version]["lora_key"] = lora_key
+                lora["versions"][lora_version]["availability"] = version.get("availability", "Public")
                 break
         # If we don't have everything required, fail
         if lora["versions"][lora_version]["adhoc"] and not lora["versions"][lora_version].get("sha256"):
@@ -843,7 +844,6 @@ class LoraModelManager(BaseModelManager):
         if is_version:
             triggers = lora["versions"][model_name].get("triggers")
         else:
-            logger.debug(lora)
             lora_version = self.get_latest_version(lora)
             if lora_version is None:
                 return None
@@ -1214,7 +1214,9 @@ class LoraModelManager(BaseModelManager):
         # logger.debug(f"Touched lora {lora_name}")
 
     def find_latest_version(self, lora) -> str | None:
-        all_versions = [int(v) for v in lora.get("versions", {}).keys()]
+        all_versions = [
+            int(v) for v in lora.get("versions", {}).keys() if lora["versions"][v].get("availability") != "EarlyAccess"
+        ]
         if len(all_versions) > 0:
             all_versions.sort(reverse=True)
             return self.ensure_is_version(all_versions[0])

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -60,6 +60,7 @@ class LoraModelManager(BaseModelManager):
     """The time to wait between checking the download queue in seconds"""
 
     _file_lock: multiprocessing_lock | nullcontext
+    _using_multiprocessing: bool = False
 
     def __init__(
         self,
@@ -88,6 +89,10 @@ class LoraModelManager(BaseModelManager):
         self._mutex = threading.Lock()
         self._file_mutex = threading.Lock()
         self._download_mutex = threading.Lock()
+
+        if multiprocessing_lock:
+            self._using_multiprocessing = True
+
         self._file_lock = multiprocessing_lock or nullcontext()
 
         self._file_count = 0
@@ -912,16 +917,18 @@ class LoraModelManager(BaseModelManager):
 
     def save_cached_reference_to_disk(self):
         with self._file_mutex, self._file_lock:
-            backup_filename = f"{self.models_db_path}-backup-{uuid.uuid4().hex[:8]}.json"
-            with open(backup_filename, "w", encoding="utf-8", errors="ignore") as outfile:
-                outfile.write(json.dumps(self.model_reference.copy(), indent=4))
-                logger.debug(
-                    f"Lora refrence backed up to {backup_filename}. "
-                    f"It contained {len(self.model_reference)} loras at time of copy.",
-                )
+            if self._using_multiprocessing:
+                backup_filename = f"{self.models_db_path}-backup-{uuid.uuid4().hex[:8]}.json"
+                with open(backup_filename, "w", encoding="utf-8", errors="ignore") as outfile:
+                    outfile.write(json.dumps(self.model_reference.copy(), indent=4))
+                    logger.debug(
+                        f"Lora refrence backed up to {backup_filename}. "
+                        f"It contained {len(self.model_reference)} loras at time of copy.",
+                    )
             with open(self.models_db_path, "w", encoding="utf-8", errors="ignore") as outfile:
                 outfile.write(json.dumps(self.model_reference.copy(), indent=4))
-            self.cleanup_lora_reference_backup_files()
+            if self._using_multiprocessing:
+                self.cleanup_lora_reference_backup_files()
 
     def find_adhoc_loras(self) -> set:
         """Returns a set of adhoc loras keys"""


### PR DESCRIPTION
- This resolves a new type of 403 possible from CivitAI where loras can be marked "EarlyAccess" and avoids attempting to download in these cases
- Additionally, we now also consider all 403s to be unrecoverable http status codes when attempting to download as its unlikely to change to a 200 simply by retrying repeatedly. 