### PR TITLE
fix: do not init model managers by default

### DIFF
--- a/hordelib/initialisation.py
+++ b/hordelib/initialisation.py
@@ -27,7 +27,7 @@ def initialise(
     force_normal_vram_mode: bool = True,
     extra_comfyui_args: list[str] | None = None,
     disable_smart_memory: bool = False,
-    do_not_load_model_mangers: bool = False,
+    do_not_load_model_mangers: bool = True,
     models_not_to_force_load: list[str] | None = None,
 ):
     """Initialise hordelib. This is required before using any other hordelib functions.

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -62,7 +62,7 @@ class SharedModelManager:
     model_reference_manager: ModelReferenceManager
     cuda_available: bool
 
-    def __new__(cls, do_not_load_model_mangers: bool = False):
+    def __new__(cls, do_not_load_model_mangers: bool = True):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls.manager = ModelManager()


### PR DESCRIPTION
This is an oversight that was, in effect, preventing the multiprocessing_lock from being passed to the model managers.