### PR TITLE
fix: better memory clearing

### DIFF
--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -427,6 +427,8 @@ def text_encoder_initial_device_hijack(*args, **kwargs):
 
 
 def unload_all_models_vram():
+    global _comfy_current_loaded_models
+
     log_free_ram()
 
     from hordelib.shared_model_manager import SharedModelManager
@@ -455,6 +457,8 @@ def unload_all_models_vram():
 
 
 def unload_all_models_ram():
+    global _comfy_current_loaded_models
+
     log_free_ram()
     from hordelib.shared_model_manager import SharedModelManager
 
@@ -467,10 +471,17 @@ def unload_all_models_ram():
     for model in _comfy_current_loaded_models:
         all_devices.add(model.device)
 
+    all_devices.add(get_torch_device())
+
     with torch.no_grad():
         for device in all_devices:
             logger.debug(f"Freeing memory on device {device}")
             _comfy_free_memory(1e30, device)
+
+        log_free_ram()
+        logger.debug("Freeing memory on CPU")
+        _comfy_free_memory(1e30, torch.device("cpu"))
+
         log_free_ram()
 
         logger.debug("Cleaning up models")

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -102,17 +102,14 @@ class SharedModelManager:
         args_passed = locals().copy()  # XXX This is temporary
         args_passed.pop("cls")  # XXX This is temporary
 
-        if download_legacy_references:
-            try:
-                cls.model_reference_manager = ModelReferenceManager(download_and_convert_legacy_dbs=True)
-            except Exception as e:
-                logger.error(f"Failed to download legacy model references: {e}")
-                logger.error(
-                    "If this continues to happen, "
-                    "github may be down or your internet connection may be having issues.",
-                )
-        else:
-            cls.model_reference_manager = ModelReferenceManager()
+        try:
+            cls.model_reference_manager = ModelReferenceManager(
+                download_and_convert_legacy_dbs=download_legacy_references,
+                override_existing=overwrite_existing_references,
+            )
+        except Exception as e:
+            logger.error(f"Failed to initialize model reference manager: {e}")
+            raise e
 
         references = {}
         for reference in managers_to_load:


### PR DESCRIPTION
I believe a combination of scoping issues and never explicitly clearing the CPU has led to an unfortunate tendency for models to not be unloaded when I was intending it.

Also includes a minor fix to the constructor call for `ModelReferenceManager` in `load_model_managers` in the off chance it fails to initialize.