### PR TITLE
fix: avoid checking lora refresh for now

### DIFF
--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -1153,6 +1153,7 @@ class LoraModelManager(BaseModelManager):
         """Returns True if a refresh has been initiated
         Else returns False
         """
+        return False  # FIXME: Slows down loras init. Need to improve this.
         lora_details = self.get_model_reference_info(lora_name)
         if not lora_details:
             return False


### PR DESCRIPTION
Quick fix to avoid refreshing loras and delaying init for 5+ seconds per job. Shouldn't even be noticed since most people are relying on versions. But I'll work on fixing this properly down the line