### PR TITLE
fix: punt lora downloads on 5xx (other than 500)

### DIFF
--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -323,6 +323,10 @@ class LoraModelManager(BaseModelManager):
                     if response.status_code == 500:
                         logger.debug(f"url '{url}' download failed with status code {response.status_code}")
                         retries += 3
+                    elif response.status_code > 500:
+                        # We're going to assume all other 5xx errors are not going to pass quickly
+                        logger.debug(f"url '{url}' download failed with status code {response.status_code}")
+                        return None
 
                 # The json being invalid is a CivitAI issue, possibly it showing an HTML page and
                 # this isn't likely to change in the next 30 seconds, so we'll try twice more


### PR DESCRIPTION
523 is 'Service Unavailable', for example. There's no sense retrying on the slight chance it comes back shortly; the service is telling us its *down right now*, its unfortunate for the user, but there's a good for the many vs good for the few pro/con here.