### PR TITLE
Adds support for Qwen

### DIFF
--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -536,6 +536,7 @@ class Comfy_Horde:
     # which our custom nodes don't allow.
     NODE_REPLACEMENTS = {
         "CheckpointLoaderSimple": "HordeCheckpointLoader",
+        "UNETLoader": "HordeCheckpointLoader",
         # "UpscaleModelLoader": "HordeUpscaleModelLoader",
         "SaveImage": "HordeImageOutput",
         "LoadImage": "HordeImageLoader",

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -382,6 +382,8 @@ def _calculate_weight_hijack(*args, **kwargs):
 
     for p in patches:
         v = p[1]
+        if not isinstance(v, tuple):
+            continue
         patch_type = v[0]
         if patch_type != "diff":
             continue
@@ -437,6 +439,14 @@ def text_encoder_initial_device_hijack(*args, **kwargs):
     return torch.device("cpu")
 
 
+def clear_gc_and_torch_cache() -> None:
+    """Clear the garbage collector and the PyTorch cache."""
+    gc.collect()
+    from torch.cuda import empty_cache
+
+    empty_cache()
+
+
 def unload_all_models_vram():
     global _comfy_current_loaded_models
 
@@ -465,6 +475,9 @@ def unload_all_models_vram():
 
     logger.debug(f"{len(SharedModelManager.manager._models_in_ram)} models cached in shared model manager")
     logger.debug(f"{len(_comfy_current_loaded_models)} models loaded in comfy")
+
+    clear_gc_and_torch_cache()
+    log_free_ram()
 
 
 def unload_all_models_ram():
@@ -505,6 +518,9 @@ def unload_all_models_ram():
 
     logger.debug(f"{len(SharedModelManager.manager._models_in_ram)} models cached in shared model manager")
     logger.debug(f"{len(_comfy_current_loaded_models)} models loaded in comfy")
+
+    clear_gc_and_torch_cache()
+    log_free_ram()
 
 
 def get_torch_device():

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -1,5 +1,6 @@
 # comfy.py
 # Wrapper around comfy to allow usage by the horde worker.
+import asyncio
 import contextlib
 import copy
 import gc
@@ -295,7 +296,12 @@ def do_comfy_import(
 
 
 # isort: on
-models_not_to_force_load: list = ["cascade", "sdxl", "flux"]  # other possible values could be `basemodel` or `sd1`
+models_not_to_force_load: list = [
+    "cascade",
+    "sdxl",
+    "flux",
+    "qwen_image",
+]  # other possible values could be `basemodel` or `sd1`
 """Models which should not be forced to load in the comfy model loading hijack.
 
 Possible values include `cascade`, `sdxl`, `basemodel`, `sd1` or any other comfyui classname
@@ -951,7 +957,7 @@ class Comfy_Horde:
             # validate_prompt from comfy returns [bool, str, list]
             # Which gives us these nice hardcoded list indexes, which valid[2] is the output node list
             self.client_id = str(uuid.uuid4())
-            valid = _comfy_validate_prompt(pipeline)
+            valid = asyncio.run(_comfy_validate_prompt(1, pipeline, []))
             import folder_paths
 
             if "embeddings" in folder_paths.filename_list_cache:

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -672,7 +672,7 @@ class Comfy_Horde:
 
     def _load_custom_nodes(self) -> None:
         """Force ComfyUI to load its normal custom nodes and the horde custom nodes."""
-        _comfy_nodes.init_extra_nodes(init_custom_nodes=True)
+        asyncio.run(_comfy_nodes.init_extra_nodes(init_custom_nodes=True))
 
     def _get_executor(self):
         """Return the ComfyUI PromptExecutor object."""

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -18,6 +18,7 @@ import uuid
 import random
 import threading
 from pprint import pformat
+import loguru
 import requests
 import psutil
 from collections.abc import Callable
@@ -181,7 +182,11 @@ class InterceptHandler(logging.Handler):
 
         # Find caller from where originated the logged message.
         frame, depth = logging.currentframe(), 2
-        while frame and frame.f_code.co_filename == logging.__file__:
+        while frame and (
+            "loguru" in frame.f_code.co_filename
+            or frame.f_code.co_filename == logging.__file__
+            or frame.f_code.co_filename == __file__
+        ):
             frame = frame.f_back
             depth += 1
 

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -557,7 +557,7 @@ class Comfy_Horde:
     # which our custom nodes don't allow.
     NODE_REPLACEMENTS = {
         "CheckpointLoaderSimple": "HordeCheckpointLoader",
-        # "UNETLoader": "HordeCheckpointLoader",
+        "UNETLoader": "HordeCheckpointLoader",
         # "UpscaleModelLoader": "HordeUpscaleModelLoader",
         "SaveImage": "HordeImageOutput",
         "LoadImage": "HordeImageLoader",

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -557,7 +557,7 @@ class Comfy_Horde:
     # which our custom nodes don't allow.
     NODE_REPLACEMENTS = {
         "CheckpointLoaderSimple": "HordeCheckpointLoader",
-        "UNETLoader": "HordeCheckpointLoader",
+        # "UNETLoader": "HordeCheckpointLoader",
         # "UpscaleModelLoader": "HordeUpscaleModelLoader",
         "SaveImage": "HordeImageOutput",
         "LoadImage": "HordeImageLoader",
@@ -636,6 +636,30 @@ class Comfy_Horde:
             [
                 _comfy_folder_names_and_paths["checkpoints"][0][0],
                 str(UserSettings.get_model_directory() / "compvis"),
+            ],
+            _comfy_supported_pt_extensions,
+        )
+
+        _comfy_folder_names_and_paths["diffusion_models"] = (
+            [
+                _comfy_folder_names_and_paths["diffusion_models"][0][0],
+                str(UserSettings.get_model_directory() / "compvis"),
+            ],
+            _comfy_supported_pt_extensions,
+        )
+
+        _comfy_folder_names_and_paths["vae"] = (
+            [
+                _comfy_folder_names_and_paths["vae"][0][0],
+                str(UserSettings.get_model_directory() / "vae"),
+            ],
+            _comfy_supported_pt_extensions,
+        )
+
+        _comfy_folder_names_and_paths["text_encoders"] = (
+            [
+                _comfy_folder_names_and_paths["text_encoders"][0][0],
+                str(UserSettings.get_model_directory() / "text_encoders"),
             ],
             _comfy_supported_pt_extensions,
         )

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -401,9 +401,9 @@ def default_json_serializer_pil_image(obj):
     return obj
 
 
-def IsChangedCache_get_hijack(self, *args, **kwargs):
+async def IsChangedCache_get_hijack(self, *args, **kwargs):
     global _comfy_is_changed_cache_get
-    result = _comfy_is_changed_cache_get(self, *args, **kwargs)
+    result = await _comfy_is_changed_cache_get(self, *args, **kwargs)
 
     global _last_pipeline_settings_hash
 
@@ -884,6 +884,7 @@ class Comfy_Horde:
     def send_sync(self, label: str, data: dict, _id: str) -> None:
         # Get receive image outputs via this async mechanism
         output = data.get("output", None)
+        logger.debug([label, output])
         images_received = None
         if output is not None and "images" in output:
             images_received = output.get("images", None)

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -928,7 +928,7 @@ class Comfy_Horde:
                         logger.error(f"Received unexpected image output from comfyui: {key}:{value}")
             logger.debug("Received output image(s) from comfyui")
         else:
-            if self._comfyui_callback is not None:
+            if self._comfyui_callback is not None and sid is not None:
                 self._comfyui_callback(label, data, sid)
 
             if label == "execution_error":
@@ -936,7 +936,8 @@ class Comfy_Horde:
                 # Reset images on error so that we receive expected None input and can raise an exception
                 self.images = None
             elif label != "executing":
-                logger.debug(f"{label}, {data}, {sid}")
+                pass
+                # logger.debug(f"{label}, {data}, {sid}")
             else:
                 node_name = data.get("node", "")
                 logger.debug(f"{label} comfyui node: {node_name}")

--- a/hordelib/config_path.py
+++ b/hordelib/config_path.py
@@ -23,5 +23,6 @@ def set_system_path() -> None:
     """Adds ComfyUI to the python path, as it is not a proper library."""
     comfyui_path = get_comfyui_path()
     sys.path.append(str(comfyui_path))
+    sys.path.append(str(comfyui_path) + "/utils")
     sys.path.append(str(comfyui_path) + "/comfy")
     sys.path.append(str(get_hordelib_path() / "nodes"))

--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -6,7 +6,7 @@ from strenum import StrEnum
 
 from hordelib.config_path import get_hordelib_path
 
-COMFYUI_VERSION = "73e04987f7e0f14bdee9baa0aafe61cf7f42a8b2"
+COMFYUI_VERSION = "71ed4a399ec76a75aa2870b772d2022e4b9a69a3"
 """The exact version of ComfyUI version to load."""
 
 REMOTE_PROXY = ""

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -631,6 +631,18 @@ class HordeLib:
         #             del payload["denoising_strength"]
         return payload, faults
 
+    def get_model_file_type(self, model_name: str) -> None | str:
+        """Get the model file type for the given model name.
+        This is used by the horde model loader node to
+        determine which model loading type to use (e.g. unet vs checkpoint)
+        """
+        model_details = None
+        if SharedModelManager.manager.compvis:
+            model_details = SharedModelManager.manager.compvis.get_model_reference_info(model_name)
+        if model_details is not None and model_details["baseline"] == "qwen_image":
+            return "unet"
+        return None  # To allow normal SD pipelines to keep working
+
     def _final_pipeline_adjustments(self, payload, pipeline_data) -> tuple[dict, list[GenMetadataEntry]]:
         payload = deepcopy(payload)
         faults: list[GenMetadataEntry] = []
@@ -906,10 +918,7 @@ class HordeLib:
             pipeline_params["model_loader_stage_c.file_type"] = "stable_cascade_stage_c"
         if "model_loader_stage_b.ckpt_name" in pipeline_params:
             pipeline_params["model_loader_stage_b.file_type"] = "stable_cascade_stage_b"
-        if model_details is not None and model_details["baseline"] == "qwen_image":
-            pipeline_params["model_loader.file_type"] = "unet"
-        else:
-            pipeline_params["model_loader.file_type"] = None  # To allow normal SD pipelines to keep working
+        pipeline_params["model_loader.file_type"] = self.get_model_file_type(payload["model_name"])
         logger.debug(f'pipeline_params["model_loader.file_type"]: {pipeline_params["model_loader.file_type"]}')
         # Inject our model manager
         # pipeline_params["model_loader.model_manager"] = SharedModelManager

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -762,6 +762,7 @@ class HordeLib:
                 else:
                     lora_name = SharedModelManager.manager.lora.get_lora_name(str(lora["name"]))
                 if lora_name is None:
+                    logger.debug(f"Lora requested '{lora['name']}' could not be found in the json DB. Ignoring!")
                     faults.append(
                         GenMetadataEntry(
                             type=METADATA_TYPE.lora,

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -899,14 +899,18 @@ class HordeLib:
         # We inject these parameters to ensure the HordeCheckpointLoader knows what file to load, if necessary
         # We don't want to hardcode this into the pipeline.json as we export this directly from ComfyUI
         # and don't want to have to rememeber to re-add those keys
+        model_details = None
+        if SharedModelManager.manager.compvis:
+            model_details = SharedModelManager.manager.compvis.get_model_reference_info(payload["model_name"])
         if "model_loader_stage_c.ckpt_name" in pipeline_params:
             pipeline_params["model_loader_stage_c.file_type"] = "stable_cascade_stage_c"
         if "model_loader_stage_b.ckpt_name" in pipeline_params:
             pipeline_params["model_loader_stage_b.file_type"] = "stable_cascade_stage_b"
-        if pipeline_params["model_loader.horde_model_name"] == "Qwen-Image_fp8":
+        if model_details is not None and model_details["baseline"] == "qwen_image":
             pipeline_params["model_loader.file_type"] = "unet"
         else:
             pipeline_params["model_loader.file_type"] = None  # To allow normal SD pipelines to keep working
+        logger.debug(f'pipeline_params["model_loader.file_type"]: {pipeline_params["model_loader.file_type"]}')
         # Inject our model manager
         # pipeline_params["model_loader.model_manager"] = SharedModelManager
         pipeline_params["model_loader.will_load_loras"] = bool(payload.get("loras"))

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -571,7 +571,6 @@ class HordeLib:
         for file_entry in model_files:
             if "file_type" in file_entry:
                 payload[file_entry["file_type"]] = file_entry["file_path"]
-                logger.debug(f"AAAAA {payload}")
 
         # Rather than specify a scheduler, only karras or not karras is specified
         if payload.get("karras", False):
@@ -900,7 +899,6 @@ class HordeLib:
         # We inject these parameters to ensure the HordeCheckpointLoader knows what file to load, if necessary
         # We don't want to hardcode this into the pipeline.json as we export this directly from ComfyUI
         # and don't want to have to rememeber to re-add those keys
-        logger.debug(f"BBBBBBB: {pipeline_params}")
         if "model_loader_stage_c.ckpt_name" in pipeline_params:
             pipeline_params["model_loader_stage_c.file_type"] = "stable_cascade_stage_c"
         if "model_loader_stage_b.ckpt_name" in pipeline_params:

--- a/hordelib/initialisation.py
+++ b/hordelib/initialisation.py
@@ -109,6 +109,9 @@ def initialise(
     sys.argv = sys_arg_bkp
 
     _is_initialised = True
+    # We need to remove comfyui path addition because it breaks
+    # module import, as it's not a proper module.
+    del sys.path[0]
 
 
 def is_initialised():

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -171,11 +171,18 @@ class BaseModelManager(ABC):
         for model_file_entry in model_file_entries:
             path_config_item = model_file_entry.get("path")
             path_config_type = model_file_entry.get("file_type")
+            directory = model_file_entry.get("directory")
             if path_config_item:
                 if path_config_item.endswith((".ckpt", ".safetensors", ".pt", ".pth", ".bin")):
                     path_entry = {"file_path": Path(path_config_item)}
+                    if directory:
+                        path_entry["file_path"] = Path(f"{directory}/{path_config_item}")
                     if path_config_type:
                         path_entry["file_type"] = path_config_type
+                    if "sha256sum" in model_file_entry:
+                        path_entry["sha256sum"] = model_file_entry.get("sha256sum")
+                    if "md5sum" in model_file_entry:
+                        path_entry["md5sum"] = model_file_entry.get("md5sum")
                     model_files.append(path_entry)
         if len(model_files) == 0:
             raise ValueError(f"Model {model_name} does not have a valid file entry")
@@ -264,26 +271,26 @@ class BaseModelManager(ABC):
         for file_entry in model_files:
             if not self.is_file_available(file_entry["file_path"]):
                 return None
-
-        file_details = self.get_model_config_files(model_name)
-
-        for file_detail in file_details:
-            if ".yaml" in file_detail["path"] or ".json" in file_detail["path"]:
-                continue
-            if not self.is_file_available(file_detail["path"]):
-                logger.debug(f"File {file_detail['path']} not found")
-                return None
-            if not skip_checksum and not self.validate_file(file_detail):
-                logger.warning(f"File {file_detail['path']} has different contents to what we expected.")
+            if not skip_checksum and not self.validate_file(file_entry):
+                logger.warning(f"File {file_entry['file_path']} has different contents to what we expected.")
                 try:
                     # The file must have been considered valid once, or we wouldn't have renamed
                     # it from the ".part" download. Likely there is an update, or a model database hash problem
-                    logger.warning(f"Likely updated, will attempt to re-download {file_detail['path']}.")
+                    logger.warning(f"Likely updated, will attempt to re-download {file_entry['file_path']}.")
                     self.taint_model(model_name)
                 except OSError as e:
-                    logger.error(f"Unable to delete {file_detail['path']}: {e}.")
-                    logger.error(f"Please delete {file_detail['path']} if this error persists.")
+                    logger.error(f"Unable to delete {file_entry['file_path']}: {e}.")
+                    logger.error(f"Please delete {file_entry['file_path']} if this error persists.")
                 return False
+
+        # FIXME: The below commented lines are already done in L267. Is this still needed?
+        # file_details = self.get_model_config_files(model_name)
+        # for file_detail in file_details:
+        #     if ".yaml" in file_detail["path"] or ".json" in file_detail["path"]:
+        #         continue
+        #     if not self.is_file_available(file_detail["path"]):
+        #         logger.debug(f"File {file_detail['path']} not found")
+        #         return None
 
         if model_name not in self.available_models:
             self.available_models.append(model_name)
@@ -371,8 +378,16 @@ class BaseModelManager(ABC):
         Checks if the file exists and if the checksum is correct
         Returns True if the file is valid, False otherwise
         """
-        full_path = f"{self.model_folder_path}/{file_details['path']}"
-
+        # TODO: It's all a bit ugly now, trying to handle both get_model_filenames()
+        # as well as direct image reference dicts
+        # But I couldn't figure out how to handle multiple files per model,
+        # where I want to place them in other locations than in compvis.
+        if "file_path" in file_details:  # This means it's an dict that was processed through get_model_filenames()
+            full_path = file_details["file_path"]
+            if isinstance(full_path, Path) and not full_path.is_absolute():
+                full_path = f"{self.model_folder_path}/{file_details['file_path']}"
+        else:
+            full_path = f"{self.model_folder_path}/{file_details['path']}"
         # Default to sha256 hashes
         if "sha256sum" in file_details:
             logger.debug(f"Getting sha256sum of {full_path}")
@@ -418,11 +433,9 @@ class BaseModelManager(ABC):
         if parsed_full_path.suffix == ".part":
             logger.debug(f"File {file_path} is a partial download, skipping")
             return False
-        sha_file_path = Path(f"{self.model_folder_path}/{parsed_full_path.stem}.sha256")
-
+        sha_file_path = Path(f"{parsed_full_path.parent}/{parsed_full_path.stem}.sha256")
         if parsed_full_path.exists() and not sha_file_path.exists() and not is_custom_model:
             self.get_file_sha256_hash(parsed_full_path)
-
         return parsed_full_path.exists() and (sha_file_path.exists() or is_custom_model)
 
     def download_file(
@@ -585,7 +598,7 @@ class BaseModelManager(ABC):
         for i in range(len(download)):
             file_path = (
                 f"{download[i]['file_path']}/{download[i]['file_name']}"
-                if "file_path" in download[i]
+                if "file_path" in download[i] and download[i]["file_path"]
                 else files[i]["path"]
             )
             download_url = None
@@ -698,7 +711,6 @@ class BaseModelManager(ABC):
                     download_succeeded = self.download_file(download_url, file_path, callback=callback)
                     if not download_succeeded:
                         return False
-
         return self.validate_model(model_name)
 
     def download_all_models(

--- a/hordelib/model_manager/lora.py
+++ b/hordelib/model_manager/lora.py
@@ -788,9 +788,9 @@ class LoraModelManager(BaseModelManager):
             if lora_name in lora:
                 return lora
         for lora in self.model_reference:
-            if fuzz.ratio(lora_name, lora) > 80:
+            if fuzz.ratio(lora_name, lora) > 83:
                 return lora
-            if fuzz.ratio(lora_name, self.model_reference[lora]["orig_name"]) > 80:
+            if fuzz.ratio(lora_name, self.model_reference[lora]["orig_name"]) > 83:
                 return lora
         return None
 

--- a/hordelib/nodes/facerestore_cf/__init__.py
+++ b/hordelib/nodes/facerestore_cf/__init__.py
@@ -266,7 +266,6 @@ class CropFace:
             if out_images.shape[0] < next_idx + faces_found:
                 print(out_images.shape)
                 print((next_idx + faces_found, 512, 512, 3))
-                print("aaaaa")
                 out_images = np.resize(out_images, (next_idx + faces_found, 512, 512, 3))
                 print(out_images.shape)
             for j in range(faces_found):

--- a/hordelib/nodes/node_model_loader.py
+++ b/hordelib/nodes/node_model_loader.py
@@ -134,7 +134,7 @@ class HordeCheckpointLoader:
             raise ValueError("No model file name provided.")
 
         with torch.no_grad():
-            if file_type is not None:
+            if file_type == "unet":
                 model_options = {}
                 if weight_dtype == "fp8_e4m3fn":
                     model_options["dtype"] = torch.float8_e4m3fn
@@ -167,7 +167,6 @@ class HordeCheckpointLoader:
                 make_regular_vae(result[2])
 
         log_free_ram()
-        logger.debug(result)
         return result
 
 

--- a/hordelib/nodes/node_model_loader.py
+++ b/hordelib/nodes/node_model_loader.py
@@ -25,8 +25,10 @@ class HordeCheckpointLoader:
                 "seamless_tiling_enabled": ("<bool>",),
                 "horde_model_name": ("<horde model name>",),
                 "ckpt_name": ("<ckpt name>",),
-                # "weight_dtype": (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],), # Unet model type
                 "file_type": ("<file type>",),  # TODO: Make this optional
+            },
+            "optional": {
+                "weight_dtype": (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],), # Unet model type
             },
         }
 
@@ -145,6 +147,7 @@ class HordeCheckpointLoader:
                     ckpt_path,
                     model_options=model_options,
                 )
+                logger.debug(result)
             else:
                 result = comfy.sd.load_checkpoint_guess_config(
                     ckpt_path,
@@ -152,10 +155,11 @@ class HordeCheckpointLoader:
                     output_clip=True,
                     embedding_directory=folder_paths.get_folder_paths("embeddings"),
                 )
-
+                logger.debug(result)
         SharedModelManager.manager._models_in_ram[horde_in_memory_name] = result, will_load_loras
 
-        if seamless_tiling_enabled and file_type in ["unet", "vae", "text_encoder"]:
+
+        if seamless_tiling_enabled and file_type not in ["unet", "vae", "text_encoder"]:
             result[0].model.apply(make_circular)
             make_circular_vae(result[2])
         else:

--- a/hordelib/nodes/node_model_loader.py
+++ b/hordelib/nodes/node_model_loader.py
@@ -25,6 +25,7 @@ class HordeCheckpointLoader:
                 "seamless_tiling_enabled": ("<bool>",),
                 "horde_model_name": ("<horde model name>",),
                 "ckpt_name": ("<ckpt name>",),
+                "weight_dtype": (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],), # Unet model type
                 "file_type": ("<file type>",),  # TODO: Make this optional
             },
         }
@@ -41,6 +42,7 @@ class HordeCheckpointLoader:
         horde_model_name: str,
         ckpt_name: str | None = None,
         file_type: str | None = None,
+        weight_dtype: str | None = None,
         output_vae=True,  # this arg is required by comfyui internals
         output_clip=True,  # this arg is required by comfyui internals
         preloading=False,
@@ -71,6 +73,10 @@ class HordeCheckpointLoader:
 
         # Check if the model was previously loaded and if so, not loaded with Loras
         if same_loaded_model and not same_loaded_model[1]:
+            if file_type in ["unet", "vae", "text_encoder"]:
+                logger.debug(f"{file_type} file was previously loaded, returning it.")
+                log_free_ram()
+                return same_loaded_model[0]
             if seamless_tiling_enabled:
                 same_loaded_model[0][0].model.apply(make_circular)
                 make_circular_vae(same_loaded_model[0][2])
@@ -119,23 +125,37 @@ class HordeCheckpointLoader:
             full_path = folder_paths.get_full_path("checkpoints", ckpt_name)
 
             if full_path is None:
-                raise ValueError(f"Checkpoint {ckpt_name} not found.")
+                raise ValueError(f"{file_type} file {ckpt_name} not found.")
 
             ckpt_path = full_path
         else:
-            raise ValueError("No checkpoint name provided.")
+            raise ValueError("No model file name provided.")
 
         with torch.no_grad():
-            result = comfy.sd.load_checkpoint_guess_config(
-                ckpt_path,
-                output_vae=True,
-                output_clip=True,
-                embedding_directory=folder_paths.get_folder_paths("embeddings"),
-            )
+            if file_type is not None:
+                model_options = {}
+                if weight_dtype == "fp8_e4m3fn":
+                    model_options["dtype"] = torch.float8_e4m3fn
+                elif weight_dtype == "fp8_e4m3fn_fast":
+                    model_options["dtype"] = torch.float8_e4m3fn
+                    model_options["fp8_optimizations"] = True
+                elif weight_dtype == "fp8_e5m2":
+                    model_options["dtype"] = torch.float8_e5m2
+                result = comfy.sd.load_diffusion_model(
+                    ckpt_path,
+                    model_options=model_options,
+                )
+            else:
+                result = comfy.sd.load_checkpoint_guess_config(
+                    ckpt_path,
+                    output_vae=True,
+                    output_clip=True,
+                    embedding_directory=folder_paths.get_folder_paths("embeddings"),
+                )
 
         SharedModelManager.manager._models_in_ram[horde_in_memory_name] = result, will_load_loras
 
-        if seamless_tiling_enabled:
+        if seamless_tiling_enabled and file_type in ["unet", "vae", "text_encoder"]:
             result[0].model.apply(make_circular)
             make_circular_vae(result[2])
         else:

--- a/hordelib/nodes/node_model_loader.py
+++ b/hordelib/nodes/node_model_loader.py
@@ -25,7 +25,7 @@ class HordeCheckpointLoader:
                 "seamless_tiling_enabled": ("<bool>",),
                 "horde_model_name": ("<horde model name>",),
                 "ckpt_name": ("<ckpt name>",),
-                "weight_dtype": (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],), # Unet model type
+                # "weight_dtype": (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],), # Unet model type
                 "file_type": ("<file type>",),  # TODO: Make this optional
             },
         }

--- a/hordelib/pipeline_designs/pipeline_qwen.json
+++ b/hordelib/pipeline_designs/pipeline_qwen.json
@@ -1,0 +1,719 @@
+{
+  "id": "91f6bbe2-ed41-4fd6-bac7-71d5b5864ecb",
+  "revision": 0,
+  "last_node_id": 75,
+  "last_link_id": 131,
+  "nodes": [
+    {
+      "id": 39,
+      "type": "VAELoader",
+      "pos": [
+        20,
+        340
+      ],
+      "size": [
+        330,
+        60
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            76
+          ]
+        }
+      ],
+      "title": "vae_loader",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "qwen_image_vae.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+            "directory": "vae"
+          }
+        ],
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "qwen_image_vae.safetensors"
+      ]
+    },
+    {
+      "id": 38,
+      "type": "CLIPLoader",
+      "pos": [
+        20,
+        190
+      ],
+      "size": [
+        330,
+        110
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            74,
+            75
+          ]
+        }
+      ],
+      "title": "clip_loader",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "CLIPLoader",
+        "models": [
+          {
+            "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+            "directory": "text_encoders"
+          }
+        ],
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+        "qwen_image",
+        "default"
+      ]
+    },
+    {
+      "id": 58,
+      "type": "EmptySD3LatentImage",
+      "pos": [
+        50,
+        510
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            107
+          ]
+        }
+      ],
+      "title": "empty_latent_image",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "EmptySD3LatentImage",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        1328,
+        1328,
+        1
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        390,
+        240
+      ],
+      "size": [
+        422.84503173828125,
+        164.31304931640625
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 74
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            46
+          ]
+        }
+      ],
+      "title": "prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "CLIPTextEncode",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "\"A vibrant, warm neon-lit street scene in Hong Kong at the afternoon, with a mix of colorful Chinese and English signs glowing brightly. The atmosphere is lively, cinematic, and rain-washed with reflections on the pavement. The colors are vivid, full of pink, blue, red, and green hues. Crowded buildings with overlapping neon signs. 1980s Hong Kong style. Signs include:\n\"龍鳳冰室\" \"金華燒臘\" \"HAPPY HAIR\" \"鴻運茶餐廳\" \"EASY BAR\" \"永發魚蛋粉\" \"添記粥麵\" \"SUNSHINE MOTEL\" \"美都餐室\" \"富記糖水\" \"太平館\" \"雅芳髮型屋\" \"STAR KTV\" \"銀河娛樂城\" \"百樂門舞廳\" \"BUBBLE CAFE\" \"萬豪麻雀館\" \"CITY LIGHTS BAR\" \"瑞祥香燭莊\" \"文記文具\" \"GOLDEN JADE HOTEL\" \"LOVELY BEAUTY\" \"合興百貨\" \"興旺電器\" And the background is warm yellow street and with all stores' lights on."
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        390,
+        440
+      ],
+      "size": [
+        425.27801513671875,
+        180.6060791015625
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 75
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            52
+          ]
+        }
+      ],
+      "title": "negative_prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "CLIPTextEncode",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        ""
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 66,
+      "type": "ModelSamplingAuraFlow",
+      "pos": [
+        850,
+        10
+      ],
+      "size": [
+        300,
+        58
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 130
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            125
+          ]
+        }
+      ],
+      "title": "model_sampling_aura_flow",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "ModelSamplingAuraFlow",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        3.1000000000000005
+      ]
+    },
+    {
+      "id": 73,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        460,
+        60
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 4,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 129
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            130
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.49",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "models": [
+          {
+            "name": "Qwen-Image-Lightning-8steps-V1.0.safetensors",
+            "url": "https://huggingface.co/lightx2v/Qwen-Image-Lightning/resolve/main/Qwen-Image-Lightning-8steps-V1.0.safetensors",
+            "directory": "loras"
+          }
+        ]
+      },
+      "widgets_values": [
+        "Qwen-Image-Lightning-8steps-V1.0.safetensors",
+        1
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        850,
+        120
+      ],
+      "size": [
+        300,
+        262
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 125
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 46
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 52
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 107
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            128
+          ]
+        }
+      ],
+      "title": "sampler",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "KSampler",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        556312751097931,
+        "randomize",
+        20,
+        2.5,
+        "euler",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 37,
+      "type": "UNETLoader",
+      "pos": [
+        20,
+        50
+      ],
+      "size": [
+        330,
+        90
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            129
+          ]
+        }
+      ],
+      "title": "model_loader",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "UNETLoader",
+        "models": [
+          {
+            "name": "qwen_image_fp8_e4m3fn.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_fp8_e4m3fn.safetensors",
+            "directory": "diffusion_models"
+          }
+        ],
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "qwen_image_fp8_e4m3fn.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1170,
+        -90
+      ],
+      "size": [
+        210,
+        46
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 128
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 76
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            131
+          ]
+        }
+      ],
+      "title": "vae_decode",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.48",
+        "Node name for S&R": "VAEDecode",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 75,
+      "type": "PreviewImage",
+      "pos": [
+        1187.1116943359375,
+        32.53653335571289
+      ],
+      "size": [
+        377.1717224121094,
+        347.790771484375
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 131
+        }
+      ],
+      "outputs": [],
+      "title": "output_image",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      46,
+      6,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      52,
+      7,
+      0,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      74,
+      38,
+      0,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      75,
+      38,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      76,
+      39,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      107,
+      58,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      125,
+      66,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      128,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      129,
+      37,
+      0,
+      73,
+      0,
+      "MODEL"
+    ],
+    [
+      130,
+      73,
+      0,
+      66,
+      0,
+      "MODEL"
+    ],
+    [
+      131,
+      8,
+      0,
+      75,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Step1 - Load models",
+      "bounding": [
+        10,
+        -20,
+        350,
+        433.6000061035156
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 2,
+      "title": "Step2 - Image size",
+      "bounding": [
+        10,
+        430,
+        350,
+        210
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 3,
+      "title": "Step3 - Prompt",
+      "bounding": [
+        380,
+        160,
+        450,
+        470
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 4,
+      "title": "Lightx2v 8steps LoRA",
+      "bounding": [
+        380,
+        -20,
+        450,
+        170
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.8390545288824294,
+      "offset": [
+        470.706034376459,
+        229.663339961336
+      ]
+    },
+    "frontendVersion": "1.25.10",
+    "ue_links": [],
+    "links_added_by_ue": [],
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/hordelib/pipelines/pipeline_qwen.json
+++ b/hordelib/pipelines/pipeline_qwen.json
@@ -1,0 +1,140 @@
+{
+  "3": {
+    "inputs": {
+      "seed": 556312751097931,
+      "steps": 20,
+      "cfg": 2.5,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "66",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "58",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "sampler"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "\"A vibrant, warm neon-lit street scene in Hong Kong at the afternoon, with a mix of colorful Chinese and English signs glowing brightly. The atmosphere is lively, cinematic, and rain-washed with reflections on the pavement. The colors are vivid, full of pink, blue, red, and green hues. Crowded buildings with overlapping neon signs. 1980s Hong Kong style. Signs include:\n\"龍鳳冰室\" \"金華燒臘\" \"HAPPY HAIR\" \"鴻運茶餐廳\" \"EASY BAR\" \"永發魚蛋粉\" \"添記粥麵\" \"SUNSHINE MOTEL\" \"美都餐室\" \"富記糖水\" \"太平館\" \"雅芳髮型屋\" \"STAR KTV\" \"銀河娛樂城\" \"百樂門舞廳\" \"BUBBLE CAFE\" \"萬豪麻雀館\" \"CITY LIGHTS BAR\" \"瑞祥香燭莊\" \"文記文具\" \"GOLDEN JADE HOTEL\" \"LOVELY BEAUTY\" \"合興百貨\" \"興旺電器\" And the background is warm yellow street and with all stores' lights on.",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "prompt"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "negative_prompt"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "vae_decode"
+    }
+  },
+  "37": {
+    "inputs": {
+      "unet_name": "qwen_image_fp8_e4m3fn.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "model_loader"
+    }
+  },
+  "38": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "clip_loader"
+    }
+  },
+  "39": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "vae_loader"
+    }
+  },
+  "58": {
+    "inputs": {
+      "width": 1328,
+      "height": 1328,
+      "batch_size": 1
+    },
+    "class_type": "EmptySD3LatentImage",
+    "_meta": {
+      "title": "empty_latent_image"
+    }
+  },
+  "66": {
+    "inputs": {
+      "shift": 3.1000000000000005,
+      "model": [
+        "37",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "model_sampling_aura_flow"
+    }
+  },
+  "75": {
+    "inputs": {
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "PreviewImage",
+    "_meta": {
+      "title": "output_image"
+    }
+  }
+}

--- a/hordelib/pipelines/pipeline_qwen.json
+++ b/hordelib/pipelines/pipeline_qwen.json
@@ -127,12 +127,13 @@
   },
   "75": {
     "inputs": {
+      "filename_prefix": "ComfyUI",
       "images": [
         "8",
         0
       ]
     },
-    "class_type": "PreviewImage",
+    "class_type": "SaveImage",
     "_meta": {
       "title": "output_image"
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ qrcode==7.4.2
 spandrel
 spandrel_extra_arches
 lpips
+av

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu124
 horde_sdk>=0.15.0
 horde_model_reference>=0.9.1
-pydantic
 numpy==1.26.4
 torch>=2.4.1
 # xformers>=0.0.19
@@ -12,13 +11,13 @@ torchdiffeq
 torchsde
 einops
 open-clip-torch
-transformers>=4.28.1
+transformers>=4.37.2
 tokenizers>=0.13.3
 sentencepiece
 safetensors>=0.4.2
 pytorch_lightning
 pynvml
-aiohttp
+aiohttp>=3.11.8
 accelerate
 pyyaml
 pillow
@@ -52,5 +51,15 @@ kornia
 qrcode==7.4.2
 spandrel
 spandrel_extra_arches
+soundfile
 lpips
-av
+av>=14.2.0
+pydantic~=2.0
+pydantic-settings~=2.0
+SQLAlchemy
+alembic
+tqdm
+yarl>=1.18.0
+comfyui-frontend-package==1.25.11
+comfyui-workflow-templates==0.1.75
+comfyui-embedded-docs==0.2.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,7 @@ _sdxl_1_0_model_name = "SDXL 1.0"
 _sdxl_refined_model_name = "AlbedoBase XL (SDXL)"
 _stable_cascade_base_model_name = "Stable Cascade 1.0"
 _flux1_schnell_fp8_base_model_name = "Flux.1-Schnell fp8 (Compact)"
-_qwen_fp8_base_model_name = "Qwen-Image_fp8"
+# _qwen_fp8_base_model_name = "Qwen-Image_fp8"
 _am_pony_xl_model_name = "AMPonyXL"
 _rev_animated_model_name = "Rev Animated"
 
@@ -133,7 +133,7 @@ _all_model_names = [
     _sdxl_refined_model_name,
     _stable_cascade_base_model_name,
     _flux1_schnell_fp8_base_model_name,
-    _qwen_fp8_base_model_name,
+    # _qwen_fp8_base_model_name,
     _am_pony_xl_model_name,
     _rev_animated_model_name,
 ]
@@ -173,10 +173,10 @@ def flux1_schnell_fp8_base_model_name(shared_model_manager: type[SharedModelMana
     return _flux1_schnell_fp8_base_model_name
 
 
-@pytest.fixture(scope="session")
-def qwen_image_fp8_base_model_name(shared_model_manager: type[SharedModelManager]) -> str:
-    """The default qwen-iimage fp8 model name used for testing."""
-    return _qwen_fp8_base_model_name
+# @pytest.fixture(scope="session")
+# def qwen_image_fp8_base_model_name(shared_model_manager: type[SharedModelManager]) -> str:
+#     """The default qwen-iimage fp8 model name used for testing."""
+#     return _qwen_fp8_base_model_name
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,12 +57,13 @@ def init_horde(
 
     HORDELIB_CUSTOM_MODELS = os.getenv("HORDELIB_CUSTOM_MODELS", None)
 
-    assert HORDELIB_CUSTOM_MODELS is not None
+    # assert HORDELIB_CUSTOM_MODELS is not None
 
     # Load the custom models json and confirm the model is on disk
     custom_models = None
-    with open(HORDELIB_CUSTOM_MODELS) as f:
-        custom_models = json.load(f)
+    if HORDELIB_CUSTOM_MODELS is not None:
+        with open(HORDELIB_CUSTOM_MODELS) as f:
+            custom_models = json.load(f)
 
     assert custom_models is not None
 
@@ -122,6 +123,7 @@ _sdxl_1_0_model_name = "SDXL 1.0"
 _sdxl_refined_model_name = "AlbedoBase XL (SDXL)"
 _stable_cascade_base_model_name = "Stable Cascade 1.0"
 _flux1_schnell_fp8_base_model_name = "Flux.1-Schnell fp8 (Compact)"
+_qwen_fp8_base_model_name = "Qwen-Image_fp8"
 _am_pony_xl_model_name = "AMPonyXL"
 _rev_animated_model_name = "Rev Animated"
 
@@ -131,6 +133,7 @@ _all_model_names = [
     _sdxl_refined_model_name,
     _stable_cascade_base_model_name,
     _flux1_schnell_fp8_base_model_name,
+    _qwen_fp8_base_model_name,
     _am_pony_xl_model_name,
     _rev_animated_model_name,
 ]
@@ -168,6 +171,12 @@ def stable_cascade_base_model_name(shared_model_manager: type[SharedModelManager
 def flux1_schnell_fp8_base_model_name(shared_model_manager: type[SharedModelManager]) -> str:
     """The default flux1-schnell fp8 model name used for testing."""
     return _flux1_schnell_fp8_base_model_name
+
+
+@pytest.fixture(scope="session")
+def qwen_image_fp8_base_model_name(shared_model_manager: type[SharedModelManager]) -> str:
+    """The default qwen-iimage fp8 model name used for testing."""
+    return _qwen_fp8_base_model_name
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ _sdxl_1_0_model_name = "SDXL 1.0"
 _sdxl_refined_model_name = "AlbedoBase XL (SDXL)"
 _stable_cascade_base_model_name = "Stable Cascade 1.0"
 _flux1_schnell_fp8_base_model_name = "Flux.1-Schnell fp8 (Compact)"
-# _qwen_fp8_base_model_name = "Qwen-Image_fp8"
+_qwen_fp8_base_model_name = "Qwen-Image_fp8"
 _am_pony_xl_model_name = "AMPonyXL"
 _rev_animated_model_name = "Rev Animated"
 
@@ -137,7 +137,7 @@ _all_model_names = [
     _sdxl_refined_model_name,
     _stable_cascade_base_model_name,
     _flux1_schnell_fp8_base_model_name,
-    # _qwen_fp8_base_model_name,
+    _qwen_fp8_base_model_name,
     _am_pony_xl_model_name,
     _rev_animated_model_name,
 ]
@@ -177,10 +177,10 @@ def flux1_schnell_fp8_base_model_name(shared_model_manager: type[SharedModelMana
     return _flux1_schnell_fp8_base_model_name
 
 
-# @pytest.fixture(scope="session")
-# def qwen_image_fp8_base_model_name(shared_model_manager: type[SharedModelManager]) -> str:
-#     """The default qwen-iimage fp8 model name used for testing."""
-#     return _qwen_fp8_base_model_name
+@pytest.fixture(scope="session")
+def qwen_image_fp8_base_model_name(shared_model_manager: type[SharedModelManager]) -> str:
+    """The default qwen-iimage fp8 model name used for testing."""
+    return _qwen_fp8_base_model_name
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,12 +90,16 @@ def init_horde(
 
     import hordelib
 
+    extra_comfyui_args = []
+    extra_comfyui_args.extend(["--reserve-vram", "1.4"])
+
     hordelib.initialise(
         setup_logging=True,
         logging_verbosity=5,
         disable_smart_memory=True,
         force_normal_vram_mode=True,
         do_not_load_model_mangers=True,
+        extra_comfyui_args=extra_comfyui_args,
         # models_not_to_force_load=[
         #     "sdxl",
         #     "cascade",

--- a/tests/model_managers/test_mm_lora.py
+++ b/tests/model_managers/test_mm_lora.py
@@ -115,8 +115,8 @@ class TestModelManagerLora:
         lora_model_manager.wait_for_adhoc_reset(15)
 
         lora_model_manager.fetch_adhoc_lora("33970", timeout=300)
-        lora_model_manager.ensure_lora_deleted("Eula Genshin Impact | Character Lora 1644")
-        lora_model_manager.fetch_adhoc_lora("Eula Genshin Impact | Character Lora 1644")
+        lora_model_manager.ensure_lora_deleted("36868")
+        lora_model_manager.fetch_adhoc_lora("36868", timeout=300)
         assert lora_model_manager.get_lora_name("33970") == str("Dehya Genshin Impact | Character Lora 809".lower())
         assert lora_model_manager.get_lora_name("Eula Genshin Impact | Character Lora 1644") == str(
             "Eula Genshin Impact | Character Lora 1644".lower(),
@@ -195,21 +195,23 @@ class TestModelManagerLora:
         assert lora_key is not None
         lora_model_manager.stop_all()
 
-    def test_adhoc_non_existing(self):
-        lora_model_manager = LoraModelManager(
-            download_wait=False,
-            allowed_adhoc_lora_storage=1024,
-        )
-        lora_model_manager.download_default_loras()
-        lora_model_manager.wait_for_downloads(600)
-        lora_model_manager.wait_for_adhoc_reset(15)
-        lora_name = (
-            "__THIS SHOULD NOT EXIST. I SWEAR IF ONE OF YOU UPLOADS A LORA WITH THIS NAME I AM GOING TO BE UPSET!"
-        )
-        lora_key = lora_model_manager.fetch_adhoc_lora(lora_name)
-        assert lora_key is None
-        assert not lora_model_manager.is_model_available(lora_name)
-        lora_model_manager.stop_all()
+    ## FIXME: CivitAI seems to have inconsistent behavior with non-existing loras.
+    ## It is returning results from loras with completely different names.
+    # def test_adhoc_non_existing(self):
+    #     lora_model_manager = LoraModelManager(
+    #         download_wait=False,
+    #         allowed_adhoc_lora_storage=1024,
+    #     )
+    #     lora_model_manager.download_default_loras()
+    #     lora_model_manager.wait_for_downloads(600)
+    #     lora_model_manager.wait_for_adhoc_reset(15)
+    #     lora_name = (
+    #         "__THIS_SHOULD_NOT_EXIST._I_SWEAR_IF_ONE_OF_YOU_UPLOADS_A_LORA_WITH_THIS_NAME_I_AM_GOING_TO_BE_UPSET!"
+    #     )
+    #     lora_key = lora_model_manager.fetch_adhoc_lora(lora_name)
+    #     assert lora_key is None
+    #     assert not lora_model_manager.is_model_available(lora_name)
+    #     lora_model_manager.stop_all()
 
     def test_adhoc_non_existing_intstring_small(self):
         lora_model_manager = LoraModelManager(

--- a/tests/model_managers/test_shared_model_manager.py
+++ b/tests/model_managers/test_shared_model_manager.py
@@ -65,6 +65,7 @@ class TestSharedModelManager:
                 model_file_details = model_manager.get_model_config_files(model)
                 for file in model_file_details:
                     path = file.get("path")
+                    directory = file.get("directory", None)
                     if not isinstance(path, str):
                         continue
                     if not (".pt" in path or ".ckpt" in path or ".safetensors" in path):
@@ -73,6 +74,8 @@ class TestSharedModelManager:
                     if os.path.isabs(path):
                         model_manager.get_file_sha256_hash(path)
                     else:
+                        if directory is not None:
+                            path = f"{directory}/{path}"
                         model_manager.get_file_sha256_hash(f"{model_manager.model_folder_path}/{path}")
 
     def test_check_validate_all_available_models(

--- a/tests/test_horde_inference_cascade.py
+++ b/tests/test_horde_inference_cascade.py
@@ -1,6 +1,7 @@
 # test_horde.py
 
 import pytest
+from loguru import logger
 from PIL import Image
 
 from hordelib.horde import HordeLib
@@ -11,6 +12,14 @@ from tests.testing_shared_functions import (
 
 
 class TestHordeInferenceCascade:
+
+    @pytest.fixture(scope="function", autouse=True)
+    def cleanup_models(self, hordelib_instance: HordeLib):
+        yield
+        from hordelib.comfy_horde import unload_all_models_ram
+
+        logger.debug("Unloading all models")
+        unload_all_models_ram()
 
     @pytest.mark.slow
     def test_cascade_text_to_image(

--- a/tests/test_horde_inference_qwen.py
+++ b/tests/test_horde_inference_qwen.py
@@ -1,0 +1,46 @@
+# test_horde.py
+
+import pytest
+from PIL import Image
+
+from hordelib.horde import HordeLib
+
+
+class TestHordeInferenceQwen:
+
+    @pytest.mark.default_qwen_model
+    def test_qwen_image_fp8_text_to_image(
+        self,
+        hordelib_instance: HordeLib,
+        qwen_image_fp8_base_model_name: str,
+    ):
+        data = {
+            "sampler_name": "k_euler",
+            "cfg_scale": 1,
+            "denoising_strength": 1.0,
+            "seed": 13122,
+            "height": 1024,
+            "width": 1024,
+            "karras": False,
+            "tiling": False,
+            "hires_fix": False,
+            "clip_skip": 1,
+            "control_type": None,
+            "image_is_control": False,
+            "return_control_map": False,
+            "prompt": 'a cyberpunk text that says "Horde Engine" floating',
+            "ddim_steps": 4,
+            "n_iter": 1,
+            "model": qwen_image_fp8_base_model_name,
+        }
+        pil_image = hordelib_instance.basic_inference_single_image(data).image
+        assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
+
+        img_filename = "qwen_image_fp8_text_to_image.png"
+        pil_image.save(f"images/{img_filename}", quality=100)
+
+        # assert check_single_inference_image_similarity(
+        #     f"images_expected/{img_filename}",
+        #     pil_image,
+        # )

--- a/tests/test_horde_inference_qwen.py
+++ b/tests/test_horde_inference_qwen.py
@@ -18,7 +18,7 @@ class TestHordeInferenceQwen:
             "sampler_name": "k_euler",
             "cfg_scale": 2.5,
             "denoising_strength": 1.0,
-            "seed": 1312,
+            "seed": 1886,
             "height": 1024,
             "width": 1024,
             "karras": False,

--- a/tests/test_horde_inference_qwen.py
+++ b/tests/test_horde_inference_qwen.py
@@ -6,41 +6,41 @@ from PIL import Image
 from hordelib.horde import HordeLib
 
 
-class TestHordeInferenceQwen:
+# class TestHordeInferenceQwen:
 
-    @pytest.mark.default_qwen_model
-    def test_qwen_image_fp8_text_to_image(
-        self,
-        hordelib_instance: HordeLib,
-        qwen_image_fp8_base_model_name: str,
-    ):
-        data = {
-            "sampler_name": "k_euler",
-            "cfg_scale": 1,
-            "denoising_strength": 1.0,
-            "seed": 13122,
-            "height": 1024,
-            "width": 1024,
-            "karras": False,
-            "tiling": False,
-            "hires_fix": False,
-            "clip_skip": 1,
-            "control_type": None,
-            "image_is_control": False,
-            "return_control_map": False,
-            "prompt": 'a cyberpunk text that says "Horde Engine" floating',
-            "ddim_steps": 4,
-            "n_iter": 1,
-            "model": qwen_image_fp8_base_model_name,
-        }
-        pil_image = hordelib_instance.basic_inference_single_image(data).image
-        assert pil_image is not None
-        assert isinstance(pil_image, Image.Image)
+#     @pytest.mark.default_qwen_model
+#     def test_qwen_image_fp8_text_to_image(
+#         self,
+#         hordelib_instance: HordeLib,
+#         qwen_image_fp8_base_model_name: str,
+#     ):
+#         data = {
+#             "sampler_name": "k_euler",
+#             "cfg_scale": 1,
+#             "denoising_strength": 1.0,
+#             "seed": 13122,
+#             "height": 1024,
+#             "width": 1024,
+#             "karras": False,
+#             "tiling": False,
+#             "hires_fix": False,
+#             "clip_skip": 1,
+#             "control_type": None,
+#             "image_is_control": False,
+#             "return_control_map": False,
+#             "prompt": 'a cyberpunk text that says "Horde Engine" floating',
+#             "ddim_steps": 4,
+#             "n_iter": 1,
+#             "model": qwen_image_fp8_base_model_name,
+#         }
+#         pil_image = hordelib_instance.basic_inference_single_image(data).image
+#         assert pil_image is not None
+#         assert isinstance(pil_image, Image.Image)
 
-        img_filename = "qwen_image_fp8_text_to_image.png"
-        pil_image.save(f"images/{img_filename}", quality=100)
+#         img_filename = "qwen_image_fp8_text_to_image.png"
+#         pil_image.save(f"images/{img_filename}", quality=100)
 
-        # assert check_single_inference_image_similarity(
-        #     f"images_expected/{img_filename}",
-        #     pil_image,
-        # )
+#         # assert check_single_inference_image_similarity(
+#         #     f"images_expected/{img_filename}",
+#         #     pil_image,
+#         # )

--- a/tests/test_horde_inference_qwen.py
+++ b/tests/test_horde_inference_qwen.py
@@ -6,41 +6,44 @@ from PIL import Image
 from hordelib.horde import HordeLib
 
 
-# class TestHordeInferenceQwen:
+class TestHordeInferenceQwen:
 
-#     @pytest.mark.default_qwen_model
-#     def test_qwen_image_fp8_text_to_image(
-#         self,
-#         hordelib_instance: HordeLib,
-#         qwen_image_fp8_base_model_name: str,
-#     ):
-#         data = {
-#             "sampler_name": "k_euler",
-#             "cfg_scale": 1,
-#             "denoising_strength": 1.0,
-#             "seed": 13122,
-#             "height": 1024,
-#             "width": 1024,
-#             "karras": False,
-#             "tiling": False,
-#             "hires_fix": False,
-#             "clip_skip": 1,
-#             "control_type": None,
-#             "image_is_control": False,
-#             "return_control_map": False,
-#             "prompt": 'a cyberpunk text that says "Horde Engine" floating',
-#             "ddim_steps": 4,
-#             "n_iter": 1,
-#             "model": qwen_image_fp8_base_model_name,
-#         }
-#         pil_image = hordelib_instance.basic_inference_single_image(data).image
-#         assert pil_image is not None
-#         assert isinstance(pil_image, Image.Image)
+    @pytest.mark.default_qwen_model
+    def test_qwen_image_fp8_text_to_image(
+        self,
+        hordelib_instance: HordeLib,
+        qwen_image_fp8_base_model_name: str,
+    ):
+        data = {
+            "sampler_name": "k_euler",
+            "cfg_scale": 2.5,
+            "denoising_strength": 1.0,
+            "seed": 1312,
+            "height": 1024,
+            "width": 1024,
+            "karras": False,
+            "tiling": False,
+            "hires_fix": False,
+            "clip_skip": 1,
+            "control_type": None,
+            "image_is_control": False,
+            "return_control_map": False,
+            "prompt": (
+                'a cyberpunk text that says "Qwen Horde Engine" in neon lights, vibrant colors, '
+                "futuristic cityscape background, high detail, digital art"
+            ),
+            "ddim_steps": 20,
+            "n_iter": 1,
+            "model": qwen_image_fp8_base_model_name,
+        }
+        pil_image = hordelib_instance.basic_inference_single_image(data).image
+        assert pil_image is not None
+        assert isinstance(pil_image, Image.Image)
 
-#         img_filename = "qwen_image_fp8_text_to_image.png"
-#         pil_image.save(f"images/{img_filename}", quality=100)
+        img_filename = "qwen_image_fp8_text_to_image.png"
+        pil_image.save(f"images/{img_filename}", quality=100)
 
-#         # assert check_single_inference_image_similarity(
-#         #     f"images_expected/{img_filename}",
-#         #     pil_image,
-#         # )
+        # assert check_single_inference_image_similarity(
+        #     f"images_expected/{img_filename}",
+        #     pil_image,
+        # )


### PR DESCRIPTION
* Supports models with multi-filetype downloads. For example Qwen requires a unet, a vae and a clip. The new code allows hordelib to download all 3. It will only keep the unet in VRAM however as the code was easy to port into our custom node loader. The vae and clip loader are much more advanced and was not possible to import into our own node loader to keep them in VRAM as well.
* Support Qwen model. However it requires min 24G of VRAM, so only the very high-end workers will be able to run it consistently.
* Switches to 71ed4a399ec76a75aa2870b772d2022e4b9a69a3 commit of comfyUI to support Qwen, which should hopefully also gives a lot of bugfixes and more features. This required some rework to support its new async definitions.