### PR TITLE
fix: non breaking mediapipe version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ scipy
 addict
 fairscale
 scikit-image
-mediapipe>=0.9.1.0
+mediapipe==0.10.21
 unidecode
 fuzzywuzzy
 strenum


### PR DESCRIPTION
`>=0.10.30` seems to have significant library API changes which break the controlnet nodes.